### PR TITLE
WP-003: PixiJS universe viewer + colony simulation (v0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,20 @@ Patchlings is an engine plus themes. It is repo-agnostic and can visualize any c
 ## 30-Second Quickstart
 
 ```bash
-npm install -g pnpm
-pnpm install
-pnpm demo
+npx pnpm@9.12.0 install
+npx pnpm@9.12.0 demo
 ```
 
 Open the viewer at:
 
 - `http://localhost:5173` (Vite dev server)
 - The runner streams at `http://localhost:4317/stream`
+- Runner-served assets live under `http://localhost:4317/patchlings-assets/`
 
 ## Run With Codex CLI
 
 ```bash
-pnpm run -- "Refactor the telemetry adapter to add backpressure summaries."
+npx pnpm@9.12.0 run -- "Refactor the telemetry adapter to add backpressure summaries."
 ```
 
 Then open `http://localhost:5173`.
@@ -30,6 +30,14 @@ Patchlings will ingest Codex JSONL from:
 ```bash
 codex exec --json "<prompt>"
 ```
+
+## Sprite Assets (Optional)
+
+Place Patchling sprites under:
+
+- `patchling_characters/patchlings_branding_images/`
+
+The runner serves them at `/patchlings-assets` by default. Override with `PATCHLINGS_ASSETS_DIR` (runner) or `VITE_PATCHLINGS_ASSET_BASE` (viewer). If assets are missing, the viewer falls back to placeholder Patchlings.
 
 ## Replay A Recording
 
@@ -97,4 +105,3 @@ See `CONTRIBUTING.md`.
 ## License
 
 MIT, see `LICENSE`.
-

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -16,6 +16,7 @@
     "@patchlings/learnlings": "workspace:*",
     "@patchlings/protocol": "workspace:*",
     "@patchlings/themes": "workspace:*",
+    "pixi.js": "^7.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { explainEvents } from "@patchlings/learnlings";
-import { universeTheme, type ThemeRenderState } from "@patchlings/themes";
 
 import { usePatchlingsStream } from "./usePatchlingsStream";
 import type { ViewerState } from "./types";
@@ -32,28 +31,60 @@ function formatTimestamp(ts: string): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
 
+function computeEventsPerSecond(events: ViewerState["recentEvents"], windowMs = 5000): number {
+  if (events.length === 0) {
+    return 0;
+  }
+  const now = Date.now();
+  const minTs = now - windowMs;
+  let count = 0;
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (!event) {
+      continue;
+    }
+    const parsed = Date.parse(event.ts);
+    if (!Number.isFinite(parsed)) {
+      continue;
+    }
+    if (parsed < minTs) {
+      break;
+    }
+    count += 1;
+  }
+  return count / (windowMs / 1000);
+}
+
 export function App(): JSX.Element {
   const state = usePatchlingsStream();
   const [learnlingsEnabled, setLearnlingsEnabled] = useState(true);
+  const [followHotspotEnabled, setFollowHotspotEnabled] = useState(true);
   const [exporting, setExporting] = useState(false);
   const [exportDetail, setExportDetail] = useState<string | null>(null);
+  const [chapterNotice, setChapterNotice] = useState<string | null>(null);
+  const noticeTimerRef = useRef<number | null>(null);
 
-  const renderState: ThemeRenderState | null = useMemo(() => {
-    if (!state.world) {
-      return null;
-    }
-    return universeTheme.reduce({
-      world: state.world,
-      events: state.recentEvents,
-      chapters: state.chapters
-    });
-  }, [state.world, state.recentEvents, state.chapters]);
+  const assetBase = (import.meta.env.VITE_PATCHLINGS_ASSET_BASE as string | undefined) ?? "/patchlings-assets";
 
   const timelineChapters = useMemo(() => sortChaptersForTimeline(state.chapters), [state.chapters]);
+  const lastTurnIndex = timelineChapters[0]?.turn_index ?? null;
   const learnlingMessages = useMemo(
     () => explainEvents(state.recentEvents.slice(-120), { limit: 7 }),
     [state.recentEvents]
   );
+  const eventsPerSecond = useMemo(() => computeEventsPerSecond(state.recentEvents), [state.recentEvents]);
+
+  const handleChapterSaved = useCallback((runId: string) => {
+    if (noticeTimerRef.current) {
+      window.clearTimeout(noticeTimerRef.current);
+    }
+    const label = lastTurnIndex ? `Turn ${lastTurnIndex}` : "Latest turn";
+    setChapterNotice(`Chapter saved for ${label} (${runId}).`);
+    noticeTimerRef.current = window.setTimeout(() => {
+      setChapterNotice(null);
+      noticeTimerRef.current = null;
+    }, 2000);
+  }, [lastTurnIndex]);
 
   const handleExportStory = async () => {
     if (exporting) {
@@ -76,6 +107,13 @@ export function App(): JSX.Element {
     }
   };
 
+  const workspaceId = state.world?.workspace_id ?? "unknown";
+  const worldChapters = state.world?.counters.chapters ?? state.chapters.length;
+  const worldEvents = state.world?.counters.events ?? state.recentEvents.length;
+  const regionCount = Object.keys(state.world?.regions ?? {}).length;
+  const fileCount = Object.keys(state.world?.files ?? {}).length;
+  const enginePatchlings = Object.keys(state.world?.patchlings ?? {}).length;
+
   return (
     <div className="app">
       <header className="topbar">
@@ -89,6 +127,18 @@ export function App(): JSX.Element {
             <span className={`status-dot ${state.connected ? "status-dot--connected" : "status-dot--disconnected"}`} />
             {state.connected ? state.status : "disconnected"}
           </div>
+
+          <div className="metric-pill">{eventsPerSecond.toFixed(1)} ev/s</div>
+          <div className="metric-pill">Turn {lastTurnIndex ?? "—"}</div>
+
+          <label className="toggle">
+            <input
+              type="checkbox"
+              checked={followHotspotEnabled}
+              onChange={(event) => setFollowHotspotEnabled(event.currentTarget.checked)}
+            />
+            <span>Follow Hotspot</span>
+          </label>
 
           <label className="toggle">
             <input
@@ -107,7 +157,19 @@ export function App(): JSX.Element {
 
       <main className="layout">
         <section className="canvas-panel">
-          <UniverseCanvas renderState={renderState} connected={state.connected} status={state.status} runId={state.runId} />
+          <UniverseCanvas
+            world={state.world}
+            events={state.recentEvents}
+            chapters={state.chapters}
+            connected={state.connected}
+            status={state.status}
+            runId={state.runId}
+            followHotspot={followHotspotEnabled}
+            assetBase={assetBase}
+            onChapterSaved={handleChapterSaved}
+          />
+
+          {chapterNotice ? <div className="chapter-notice">{chapterNotice}</div> : null}
 
           {learnlingsEnabled ? (
             <aside className="learnlings-panel">
@@ -132,23 +194,35 @@ export function App(): JSX.Element {
         <aside className="sidebar">
           <section className="panel">
             <h2>World</h2>
-            {renderState ? (
+            {state.world ? (
               <ul className="kv-list">
                 <li>
                   <span>Workspace</span>
-                  <strong>{renderState.meta.workspaceId}</strong>
+                  <strong>{workspaceId}</strong>
                 </li>
                 <li>
                   <span>Chapters</span>
-                  <strong>{renderState.meta.chapterCount}</strong>
+                  <strong>{worldChapters}</strong>
                 </li>
                 <li>
                   <span>Events</span>
-                  <strong>{renderState.meta.counters.events}</strong>
+                  <strong>{worldEvents}</strong>
                 </li>
                 <li>
-                  <span>Patchlings</span>
-                  <strong>{Object.keys(state.world?.patchlings ?? {}).length}</strong>
+                  <span>Regions</span>
+                  <strong>{regionCount}</strong>
+                </li>
+                <li>
+                  <span>Files</span>
+                  <strong>{fileCount}</strong>
+                </li>
+                <li>
+                  <span>Engine Patchlings</span>
+                  <strong>{enginePatchlings}</strong>
+                </li>
+                <li>
+                  <span>Assets</span>
+                  <strong>{assetBase}</strong>
                 </li>
               </ul>
             ) : (

--- a/apps/viewer/src/UniverseCanvas.tsx
+++ b/apps/viewer/src/UniverseCanvas.tsx
@@ -1,260 +1,75 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 
-import type { ThemeRenderState, ThemeRegion } from "@patchlings/themes";
+import type { ChapterSummary, WorldState } from "@patchlings/engine";
+import type { TelemetryEventV1 } from "@patchlings/protocol";
 
 import type { RunStatus } from "./types";
+import { ColonySimulation } from "./colony/simulation";
 
 interface UniverseCanvasProps {
-  renderState: ThemeRenderState | null;
+  world: WorldState | null;
+  events: TelemetryEventV1[];
+  chapters: ChapterSummary[];
   connected: boolean;
   status: RunStatus;
   runId: string;
+  followHotspot: boolean;
+  assetBase: string;
+  onChapterSaved?: (runId: string) => void;
 }
 
-interface Vec2 {
-  x: number;
-  y: number;
-}
-
-const STAR_COUNT = 120;
-const FILES_PER_REGION_LIMIT = 220;
-
-function hashString(input: string): number {
-  let hash = 2166136261;
-  for (let i = 0; i < input.length; i += 1) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-function lcg(seed: number): () => number {
-  let state = seed >>> 0;
-  return () => {
-    state = Math.imul(1664525, state) + 1013904223;
-    return (state >>> 0) / 4294967296;
-  };
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function regionRadius(region: ThemeRegion): number {
-  const base = 26;
-  const sizeFactor = Math.sqrt(region.fileCount + 1) * 2.2;
-  const touchFactor = Math.log10(region.touchCount + 10) * 8;
-  return clamp(base + sizeFactor + touchFactor, 28, 92);
-}
-
-function positionRegions(regions: ThemeRegion[], center: Vec2, radius: number): Map<string, Vec2> {
-  const positions = new Map<string, Vec2>();
-  const count = Math.max(1, regions.length);
-  regions.forEach((region, index) => {
-    const angle = (index / count) * Math.PI * 2 - Math.PI / 2;
-    const r = radius * (0.72 + (index % 3) * 0.08);
-    positions.set(region.id, {
-      x: center.x + Math.cos(angle) * r,
-      y: center.y + Math.sin(angle) * r
-    });
-  });
-  return positions;
-}
-
-function positionFile(fileId: string, regionCenter: Vec2, regionR: number): Vec2 {
-  const seed = hashString(fileId);
-  const rnd = lcg(seed);
-  const angle = rnd() * Math.PI * 2;
-  const radius = regionR * (0.3 + rnd() * 0.65);
-  return {
-    x: regionCenter.x + Math.cos(angle) * radius,
-    y: regionCenter.y + Math.sin(angle) * radius
-  };
-}
-
-function drawBackground(ctx: CanvasRenderingContext2D, width: number, height: number, seed: number): void {
-  const gradient = ctx.createLinearGradient(0, 0, 0, height);
-  gradient.addColorStop(0, "#05070f");
-  gradient.addColorStop(1, "#0b1021");
-  ctx.fillStyle = gradient;
-  ctx.fillRect(0, 0, width, height);
-
-  const rnd = lcg(seed);
-  for (let i = 0; i < STAR_COUNT; i += 1) {
-    const x = rnd() * width;
-    const y = rnd() * height;
-    const alpha = 0.2 + rnd() * 0.6;
-    const size = 0.8 + rnd() * 1.8;
-    ctx.fillStyle = `rgba(180, 210, 255, ${alpha.toFixed(3)})`;
-    ctx.beginPath();
-    ctx.arc(x, y, size, 0, Math.PI * 2);
-    ctx.fill();
-  }
-}
-
-function drawStatusOverlay(ctx: CanvasRenderingContext2D, width: number, connected: boolean, status: RunStatus, runId: string): void {
-  const text = connected ? `Run: ${runId} • ${status}` : "Waiting for runner…";
-  ctx.save();
-  ctx.font = "12px ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif";
-  ctx.fillStyle = "rgba(210, 225, 255, 0.85)";
-  ctx.fillText(text, 16, 24);
-  ctx.restore();
-
-  ctx.save();
-  ctx.strokeStyle = connected ? "rgba(90, 200, 140, 0.8)" : "rgba(255, 120, 120, 0.8)";
-  ctx.lineWidth = 2;
-  ctx.beginPath();
-  ctx.arc(width - 24, 24, 8, 0, Math.PI * 2);
-  ctx.stroke();
-  ctx.restore();
-}
-
-export function UniverseCanvas({ renderState, connected, status, runId }: UniverseCanvasProps): JSX.Element {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const rafRef = useRef<number | null>(null);
-  const sizeRef = useRef({ width: 0, height: 0, dpr: 1 });
-
-  const backgroundSeed = useMemo(() => hashString(renderState?.meta.workspaceId ?? "patchlings"), [renderState?.meta.workspaceId]);
-
-  const scheduleDraw = () => {
-    if (rafRef.current !== null) {
-      cancelAnimationFrame(rafRef.current);
-    }
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      const canvas = canvasRef.current;
-      if (!canvas) {
-        return;
-      }
-      const ctx = canvas.getContext("2d");
-      if (!ctx) {
-        return;
-      }
-
-      const { width, height, dpr } = sizeRef.current;
-      ctx.save();
-      ctx.scale(dpr, dpr);
-      drawBackground(ctx, width, height, backgroundSeed);
-
-      if (renderState) {
-        const center: Vec2 = { x: width / 2, y: height / 2 };
-        const ringRadius = Math.min(width, height) * 0.32;
-        const regions = renderState.regions.slice(0, 18);
-        const regionPositions = positionRegions(regions, center, ringRadius);
-
-        for (const region of regions) {
-          const position = regionPositions.get(region.id);
-          if (!position) {
-            continue;
-          }
-          const r = regionRadius(region);
-          const glow = ctx.createRadialGradient(position.x, position.y, r * 0.2, position.x, position.y, r * 1.6);
-          glow.addColorStop(0, "rgba(120, 180, 255, 0.28)");
-          glow.addColorStop(1, "rgba(40, 70, 130, 0.02)");
-          ctx.fillStyle = glow;
-          ctx.beginPath();
-          ctx.arc(position.x, position.y, r * 1.6, 0, Math.PI * 2);
-          ctx.fill();
-
-          ctx.fillStyle = "rgba(120, 180, 255, 0.5)";
-          ctx.beginPath();
-          ctx.arc(position.x, position.y, r, 0, Math.PI * 2);
-          ctx.fill();
-
-          ctx.strokeStyle = "rgba(190, 220, 255, 0.7)";
-          ctx.lineWidth = 1.5;
-          ctx.beginPath();
-          ctx.arc(position.x, position.y, r, 0, Math.PI * 2);
-          ctx.stroke();
-        }
-
-        const filesByRegion = new Map<string, typeof renderState.files>();
-        for (const file of renderState.files) {
-          const list = filesByRegion.get(file.regionId);
-          if (list) {
-            list.push(file);
-          } else {
-            filesByRegion.set(file.regionId, [file]);
-          }
-        }
-
-        for (const region of regions) {
-          const regionCenter = regionPositions.get(region.id);
-          if (!regionCenter) {
-            continue;
-          }
-          const r = regionRadius(region);
-          const files = (filesByRegion.get(region.id) ?? []).slice(0, FILES_PER_REGION_LIMIT);
-          for (const file of files) {
-            const position = positionFile(file.id, regionCenter, r);
-            const intensity = clamp(Math.log10(file.touchCount + 10) / 2.2, 0.15, 1);
-            ctx.fillStyle = `rgba(255, 230, 180, ${0.22 + intensity * 0.6})`;
-            ctx.beginPath();
-            ctx.arc(position.x, position.y, 1.6 + intensity * 1.8, 0, Math.PI * 2);
-            ctx.fill();
-          }
-        }
-
-        const patchlings = renderState.patchlings.slice(0, 80);
-        const patchlingOrbit = Math.min(width, height) * 0.42;
-        patchlings.forEach((patchling, index) => {
-          const seed = hashString(patchling.id);
-          const rnd = lcg(seed);
-          const angle = (index / Math.max(1, patchlings.length)) * Math.PI * 2 + rnd() * 0.3;
-          const radius = patchlingOrbit * (0.82 + rnd() * 0.12);
-          const x = center.x + Math.cos(angle) * radius;
-          const y = center.y + Math.sin(angle) * radius;
-          const size = 4 + clamp(Math.log2(patchling.callCount + 1), 0, 6);
-
-          ctx.fillStyle = "rgba(140, 255, 190, 0.85)";
-          ctx.fillRect(x - size / 2, y - size / 2, size, size);
-          ctx.strokeStyle = "rgba(40, 120, 80, 0.8)";
-          ctx.lineWidth = 1;
-          ctx.strokeRect(x - size / 2, y - size / 2, size, size);
-        });
-      }
-
-      drawStatusOverlay(ctx, width, connected, status, runId);
-      ctx.restore();
-    });
-  };
+export function UniverseCanvas(props: UniverseCanvasProps): JSX.Element {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const simRef = useRef<ColonySimulation | null>(null);
 
   useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
+    const host = hostRef.current;
+    if (!host) {
       return;
     }
-
-    const resize = () => {
-      const rect = canvas.getBoundingClientRect();
-      const dpr = clamp(window.devicePixelRatio || 1, 1, 2);
-      sizeRef.current = { width: rect.width, height: rect.height, dpr };
-      canvas.width = Math.max(1, Math.floor(rect.width * dpr));
-      canvas.height = Math.max(1, Math.floor(rect.height * dpr));
-      scheduleDraw();
-    };
-
-    resize();
-    window.addEventListener("resize", resize);
+    const options = props.onChapterSaved
+      ? {
+          assetBase: props.assetBase,
+          followHotspot: props.followHotspot,
+          onChapterSaved: props.onChapterSaved
+        }
+      : {
+          assetBase: props.assetBase,
+          followHotspot: props.followHotspot
+        };
+    const sim = new ColonySimulation(host, options);
+    simRef.current = sim;
     return () => {
-      window.removeEventListener("resize", resize);
+      sim.destroy();
+      simRef.current = null;
     };
+    // We intentionally create the simulation once and update it via effects below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    scheduleDraw();
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [renderState, connected, status, runId, backgroundSeed]);
+    simRef.current?.setFollowHotspot(props.followHotspot);
+  }, [props.followHotspot]);
 
-  return (
-    <div className="universe-canvas">
-      <canvas ref={canvasRef} />
-    </div>
-  );
+  useEffect(() => {
+    simRef.current?.setConnection(props.connected, props.status, props.runId);
+  }, [props.connected, props.status, props.runId]);
+
+  useEffect(() => {
+    simRef.current?.ingestWorld(props.world);
+  }, [props.world]);
+
+  useEffect(() => {
+    simRef.current?.ingestChapters(props.chapters);
+  }, [props.chapters]);
+
+  useEffect(() => {
+    simRef.current?.ingestEvents(props.events);
+  }, [props.events]);
+
+  useEffect(() => {
+    void simRef.current?.setAssetBase(props.assetBase);
+  }, [props.assetBase]);
+
+  return <div className="universe-canvas" ref={hostRef} />;
 }
-

--- a/apps/viewer/src/colony/assets.ts
+++ b/apps/viewer/src/colony/assets.ts
@@ -1,0 +1,239 @@
+import { Assets, Rectangle, Texture } from "pixi.js";
+
+export type PatchlingAction = "idle" | "walk" | "carry";
+export type PatchlingDir = "N" | "E" | "S" | "W";
+
+export interface PatchlingSpriteSet {
+  mode: "sprites" | "placeholder";
+  size: number;
+  assetBase: string;
+  animations: Record<PatchlingAction, Record<PatchlingDir, Texture[]>>;
+  warnings: string[];
+}
+
+export interface PatchlingSpriteOptions {
+  assetBase: string;
+  size?: number;
+  frameCount?: number;
+}
+
+const ACTIONS: PatchlingAction[] = ["idle", "walk", "carry"];
+const DIRECTIONS: PatchlingDir[] = ["S", "E", "N", "W"];
+const DIR_TO_TOKEN: Record<PatchlingDir, string> = {
+  S: "s",
+  E: "e",
+  N: "n",
+  W: "w"
+};
+const ROW_BY_DIR: Record<PatchlingDir, number> = {
+  S: 0,
+  E: 1,
+  N: 2,
+  W: 3
+};
+
+const DEFAULT_SIZE = 128;
+const DEFAULT_FRAME_COUNT = 6;
+
+function normalizeAssetBase(assetBase: string): string {
+  const trimmed = assetBase.trim();
+  if (!trimmed) {
+    return "/patchlings-assets";
+  }
+  return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+}
+
+function assetUrl(assetBase: string, relativePath: string): string {
+  const base = normalizeAssetBase(assetBase);
+  const rel = relativePath.replace(/^\/+/, "");
+  return `${base}/${rel}`;
+}
+
+async function assetExists(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: "HEAD" });
+    if (response.ok) {
+      return true;
+    }
+    if (response.status === 405) {
+      const getResponse = await fetch(url, { method: "GET" });
+      return getResponse.ok;
+    }
+    return false;
+  } catch (error) {
+    return false;
+  }
+}
+
+function placeholderAnimations(): Record<PatchlingAction, Record<PatchlingDir, Texture[]>> {
+  const animations = {} as Record<PatchlingAction, Record<PatchlingDir, Texture[]>>;
+  for (const action of ACTIONS) {
+    const perDir = {} as Record<PatchlingDir, Texture[]>;
+    for (const dir of DIRECTIONS) {
+      perDir[dir] = [Texture.WHITE];
+    }
+    animations[action] = perDir;
+  }
+  return animations;
+}
+
+function warningsForMissingAssets(assetBase: string): string[] {
+  const base = normalizeAssetBase(assetBase);
+  return [
+    "[patchlings/viewer] Sprite assets not found. Falling back to placeholder circles.",
+    `[patchlings/viewer] Expected sheets under: ${base}/sprites_v1/sheets/`,
+    `[patchlings/viewer] Expected frames under: ${base}/sprites_v1/sprites/`,
+    "[patchlings/viewer] Canonical repo asset root: patchling_characters/patchlings_branding_images/"
+  ];
+}
+
+function sliceSheetTextures(texture: Texture, size: number): Record<PatchlingDir, Texture[]> | null {
+  const columns = Math.max(1, Math.floor(texture.width / size));
+  const rows = Math.max(1, Math.floor(texture.height / size));
+  if (rows < 4 || columns < 1) {
+    return null;
+  }
+
+  const perDir = {} as Record<PatchlingDir, Texture[]>;
+  for (const dir of DIRECTIONS) {
+    const rowIndex = ROW_BY_DIR[dir];
+    const textures: Texture[] = [];
+    for (let col = 0; col < columns; col += 1) {
+      const frame = new Rectangle(col * size, rowIndex * size, size, size);
+      textures.push(new Texture(texture.baseTexture, frame));
+    }
+    perDir[dir] = textures.length > 0 ? textures : [texture];
+  }
+  return perDir;
+}
+
+async function loadSheetAnimations(
+  assetBase: string,
+  size: number
+): Promise<Record<PatchlingAction, Record<PatchlingDir, Texture[]>> | null> {
+  const sheetUrls = {
+    idle: assetUrl(assetBase, `sprites_v1/sheets/patchling_idle_sheet_${size}.png`),
+    walk: assetUrl(assetBase, `sprites_v1/sheets/patchling_walk_sheet_${size}.png`),
+    carry: assetUrl(assetBase, `sprites_v1/sheets/patchling_carry_sheet_${size}.png`)
+  } as const;
+
+  const existsChecks = await Promise.all(Object.values(sheetUrls).map((url) => assetExists(url)));
+  if (existsChecks.some((exists) => !exists)) {
+    return null;
+  }
+
+  try {
+    const [idleTexture, walkTexture, carryTexture] = await Promise.all([
+      Assets.load(sheetUrls.idle),
+      Assets.load(sheetUrls.walk),
+      Assets.load(sheetUrls.carry)
+    ]);
+
+    const idle = sliceSheetTextures(idleTexture as Texture, size);
+    const walk = sliceSheetTextures(walkTexture as Texture, size);
+    const carry = sliceSheetTextures(carryTexture as Texture, size);
+    if (!idle || !walk || !carry) {
+      return null;
+    }
+
+    return {
+      idle,
+      walk,
+      carry
+    };
+  } catch (error) {
+    return null;
+  }
+}
+
+async function loadFrameAnimations(
+  assetBase: string,
+  size: number,
+  frameCount: number
+): Promise<Record<PatchlingAction, Record<PatchlingDir, Texture[]>> | null> {
+  const probeUrl = assetUrl(
+    assetBase,
+    `sprites_v1/sprites/patchling_idle_s_01_${size}.png`
+  );
+  if (!(await assetExists(probeUrl))) {
+    return null;
+  }
+
+  const animations = {} as Record<PatchlingAction, Record<PatchlingDir, Texture[]>>;
+
+  for (const action of ACTIONS) {
+    const perDir = {} as Record<PatchlingDir, Texture[]>;
+    for (const dir of DIRECTIONS) {
+      const token = DIR_TO_TOKEN[dir];
+      const textures: Texture[] = [];
+      for (let frameIndex = 1; frameIndex <= frameCount; frameIndex += 1) {
+        const frameToken = String(frameIndex).padStart(2, "0");
+        const url = assetUrl(
+          assetBase,
+          `sprites_v1/sprites/patchling_${action}_${token}_${frameToken}_${size}.png`
+        );
+        try {
+          const texture = (await Assets.load(url)) as Texture;
+          textures.push(texture);
+        } catch (error) {
+          // Ignore missing frames; we will fall back to any available frames.
+        }
+      }
+      perDir[dir] = textures.length > 0 ? textures : [Texture.WHITE];
+    }
+    animations[action] = perDir;
+  }
+
+  const hasRealTextures = ACTIONS.some((action) =>
+    DIRECTIONS.some((dir) =>
+      animations[action][dir].some((texture) => texture !== Texture.WHITE)
+    )
+  );
+
+  return hasRealTextures ? animations : null;
+}
+
+export async function loadPatchlingSprites(
+  options: PatchlingSpriteOptions
+): Promise<PatchlingSpriteSet> {
+  const size = options.size ?? DEFAULT_SIZE;
+  const frameCount = options.frameCount ?? DEFAULT_FRAME_COUNT;
+  const assetBase = normalizeAssetBase(options.assetBase);
+
+  const fromSheets = await loadSheetAnimations(assetBase, size);
+  if (fromSheets) {
+    return {
+      mode: "sprites",
+      size,
+      assetBase,
+      animations: fromSheets,
+      warnings: []
+    };
+  }
+
+  const fromFrames = await loadFrameAnimations(assetBase, size, frameCount);
+  if (fromFrames) {
+    return {
+      mode: "sprites",
+      size,
+      assetBase,
+      animations: fromFrames,
+      warnings: [
+        "[patchlings/viewer] Sprite sheets missing; using individual frames instead."
+      ]
+    };
+  }
+
+  const warnings = warningsForMissingAssets(assetBase);
+  for (const warning of warnings) {
+    console.warn(warning);
+  }
+
+  return {
+    mode: "placeholder",
+    size,
+    assetBase,
+    animations: placeholderAnimations(),
+    warnings
+  };
+}

--- a/apps/viewer/src/colony/jobs.ts
+++ b/apps/viewer/src/colony/jobs.ts
@@ -1,0 +1,223 @@
+import type { TelemetryAttrs, TelemetryEventV1 } from "@patchlings/protocol";
+
+export type StationId = "board" | "library" | "forge" | "terminal" | "gate" | "archive";
+
+export type JobType =
+  | "TURN_START"
+  | "TURN_COMPLETE"
+  | "FILE_READ"
+  | "FILE_WRITE"
+  | "TEST_RUN"
+  | "TEST_PASS"
+  | "TEST_FAIL"
+  | "APPROVAL_WAIT"
+  | "TOOL_RUN";
+
+export interface JobSeed {
+  id: string;
+  eventKey: string;
+  type: JobType;
+  stationId: StationId;
+  runId: string;
+  seq: number;
+  ts: string;
+  eventName: string;
+  severity?: TelemetryEventV1["severity"];
+  districtId?: string;
+  buildingId?: string;
+  metadata: {
+    kind: TelemetryEventV1["kind"];
+    name: string;
+  };
+}
+
+function pickString(attrs: TelemetryAttrs | undefined, keys: string[]): string | undefined {
+  if (!attrs) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = attrs[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export function stableRegionId(attrs: TelemetryAttrs | undefined): string | undefined {
+  return pickString(attrs, [
+    "path_stable_dir_hash",
+    "file_path_stable_dir_hash",
+    "target_path_stable_dir_hash",
+    "source_path_stable_dir_hash",
+    "path_dir_hash",
+    "file_path_dir_hash",
+    "target_path_dir_hash",
+    "source_path_dir_hash"
+  ]);
+}
+
+export function stablePathId(attrs: TelemetryAttrs | undefined): string | undefined {
+  return pickString(attrs, [
+    "path_stable_hash",
+    "file_path_stable_hash",
+    "target_path_stable_hash",
+    "source_path_stable_hash",
+    "path_hash",
+    "file_path_hash",
+    "target_path_hash",
+    "source_path_hash"
+  ]);
+}
+
+function looksLikeApproval(event: TelemetryEventV1): boolean {
+  const name = event.name.toLowerCase();
+  if (name.includes("approval") || name.includes("gate")) {
+    return true;
+  }
+  const attrs = event.attrs;
+  if (!attrs) {
+    return false;
+  }
+  return (
+    attrs.approval === true ||
+    attrs.approval_state === "wait" ||
+    attrs.approval_state === "pending"
+  );
+}
+
+function fileJobType(name: string): JobType {
+  if (name.includes("read")) {
+    return "FILE_READ";
+  }
+  return "FILE_WRITE";
+}
+
+function testJobType(name: string): JobType {
+  if (name.includes("fail")) {
+    return "TEST_FAIL";
+  }
+  if (name.includes("pass")) {
+    return "TEST_PASS";
+  }
+  return "TEST_RUN";
+}
+
+export function mapEventToJobSeed(event: TelemetryEventV1): JobSeed | null {
+  const eventKey = `${event.run_id}:${event.seq}`;
+  const nameLower = event.name.toLowerCase();
+
+  if (event.kind === "turn") {
+    if (event.name === "turn.started") {
+      return {
+        id: `job:${eventKey}`,
+        eventKey,
+        type: "TURN_START",
+        stationId: "board",
+        runId: event.run_id,
+        seq: event.seq,
+        ts: event.ts,
+        eventName: event.name,
+        metadata: { kind: event.kind, name: event.name }
+      };
+    }
+
+    if (event.name === "turn.completed" || event.name === "turn.failed") {
+      return {
+        id: `job:${eventKey}`,
+        eventKey,
+        type: "TURN_COMPLETE",
+        stationId: "archive",
+        runId: event.run_id,
+        seq: event.seq,
+        ts: event.ts,
+        eventName: event.name,
+        severity: event.severity,
+        metadata: { kind: event.kind, name: event.name }
+      };
+    }
+  }
+
+  if (looksLikeApproval(event)) {
+    return {
+      id: `job:${eventKey}`,
+      eventKey,
+      type: "APPROVAL_WAIT",
+      stationId: "gate",
+      runId: event.run_id,
+      seq: event.seq,
+      ts: event.ts,
+      eventName: event.name,
+      severity: event.severity,
+      metadata: { kind: event.kind, name: event.name }
+    };
+  }
+
+  if (event.kind === "file") {
+    const regionId = stableRegionId(event.attrs) ?? "region.unknown";
+    const pathId = stablePathId(event.attrs) ?? `file:${eventKey}`;
+    return {
+      id: `job:${eventKey}`,
+      eventKey,
+      type: fileJobType(nameLower),
+      stationId: fileJobType(nameLower) === "FILE_READ" ? "library" : "forge",
+      runId: event.run_id,
+      seq: event.seq,
+      ts: event.ts,
+      eventName: event.name,
+      severity: event.severity,
+      districtId: regionId,
+      buildingId: pathId,
+      metadata: { kind: event.kind, name: event.name }
+    };
+  }
+
+  if (event.kind === "test") {
+    const type = testJobType(nameLower);
+    return {
+      id: `job:${eventKey}`,
+      eventKey,
+      type,
+      stationId: "terminal",
+      runId: event.run_id,
+      seq: event.seq,
+      ts: event.ts,
+      eventName: event.name,
+      severity: event.severity,
+      metadata: { kind: event.kind, name: event.name }
+    };
+  }
+
+  if (event.kind === "tool") {
+    return {
+      id: `job:${eventKey}`,
+      eventKey,
+      type: "TOOL_RUN",
+      stationId: "terminal",
+      runId: event.run_id,
+      seq: event.seq,
+      ts: event.ts,
+      eventName: event.name,
+      severity: event.severity,
+      metadata: { kind: event.kind, name: event.name }
+    };
+  }
+
+  if (event.kind === "error") {
+    return {
+      id: `job:${eventKey}`,
+      eventKey,
+      type: "TEST_FAIL",
+      stationId: "terminal",
+      runId: event.run_id,
+      seq: event.seq,
+      ts: event.ts,
+      eventName: event.name,
+      severity: "error",
+      metadata: { kind: event.kind, name: event.name }
+    };
+  }
+
+  return null;
+}
+

--- a/apps/viewer/src/colony/simulation.ts
+++ b/apps/viewer/src/colony/simulation.ts
@@ -1,0 +1,1754 @@
+import { AnimatedSprite, Application, Container, Graphics, Text, Texture } from "pixi.js";
+
+import type { ChapterSummary, WorldState } from "@patchlings/engine";
+import type { TelemetryEventV1 } from "@patchlings/protocol";
+
+import { loadPatchlingSprites, type PatchlingAction, type PatchlingDir, type PatchlingSpriteSet } from "./assets";
+import { mapEventToJobSeed, type JobSeed, type JobType, type StationId } from "./jobs";
+
+export type RunStatus = "idle" | "running" | "completed" | "failed";
+
+export interface ColonySimulationOptions {
+  assetBase: string;
+  followHotspot: boolean;
+  onChapterSaved?: (runId: string) => void;
+}
+
+interface Layers {
+  worldRoot: Container;
+  groundLayer: Container;
+  pathLayer: Container;
+  buildingsLayer: Container;
+  propsLayer: Container;
+  agentsLayer: Container;
+  fxLayer: Container;
+  uiWorldLayer: Container;
+  hudLayer: Container;
+}
+
+interface Vec2 {
+  x: number;
+  y: number;
+}
+
+interface CameraState {
+  x: number;
+  y: number;
+  targetX: number;
+  targetY: number;
+  scale: number;
+  targetScale: number;
+  dragging: boolean;
+  dragStart: Vec2;
+  dragCameraStart: Vec2;
+  followSuppressedUntil: number;
+}
+
+interface Station {
+  id: StationId;
+  label: string;
+  position: Vec2;
+  radius: number;
+  container: Container;
+  pad: Graphics;
+  glow: Graphics;
+  queueSpots?: Vec2[];
+}
+
+interface District {
+  id: string;
+  index: number;
+  center: Vec2;
+  radius: number;
+  ring: Graphics;
+}
+
+interface Building {
+  id: string;
+  districtId: string;
+  position: Vec2;
+  writes: number;
+  stage: number;
+  sprite: Graphics;
+  lastTs: string;
+}
+
+interface Job {
+  id: string;
+  seed: JobSeed;
+  type: JobType;
+  stationId: StationId;
+  districtId: string;
+  buildingId: string | undefined;
+  createdAt: number;
+  assignedAgentId?: string;
+  step: "to_station" | "to_target" | "interact" | "done";
+  stepStartedAt: number;
+}
+
+interface Agent {
+  id: string;
+  role: "builder" | "learner" | "narrator";
+  state: "idle" | "walk" | "carry" | "interact";
+  dir: PatchlingDir;
+  animState: PatchlingAction;
+  animDir: PatchlingDir;
+  animKey: string;
+  pos: Vec2;
+  targetPos: Vec2;
+  speed: number;
+  payload: "none" | "block";
+  jobId: string | undefined;
+  anchorStationId?: StationId;
+  container: Container;
+  sprite: AnimatedSprite;
+  shadow: Graphics;
+  bubble?: Text;
+  block?: Graphics;
+}
+
+interface PulseFx {
+  id: string;
+  position: Vec2;
+  color: number;
+  ttlMs: number;
+  startedAt: number;
+  graphic: Graphics;
+}
+
+interface PuffFx {
+  id: string;
+  position: Vec2;
+  color: number;
+  ttlMs: number;
+  startedAt: number;
+  graphic: Graphics;
+}
+
+const WORLD_HALF_SIZE = 2400;
+const MAX_DISTRICTS = 120;
+const MAX_BUILDINGS = 600;
+const DISTRICT_SPACING = 160;
+const BUILDING_MIN_RADIUS = 40;
+const BUILDING_MAX_RADIUS = 120;
+const MAX_AGENTS = 40;
+const BASE_AGENT_COUNT = 8;
+const JOB_SPAWN_THRESHOLD = 10;
+const MAX_PULSES = 120;
+const MAX_PUFFS = 80;
+const HOTSPOT_LINGER_MS = 10_000;
+
+const MIN_ZOOM = 0.45;
+const MAX_ZOOM = 1.9;
+
+const INITIAL_CAMERA = {
+  x: -200,
+  y: -400,
+  scale: 0.88
+} as const;
+
+const STATION_LAYOUT: Record<StationId, Vec2> = {
+  board: { x: -820, y: -420 },
+  library: { x: -1220, y: -40 },
+  forge: { x: -420, y: 380 },
+  terminal: { x: 420, y: -380 },
+  gate: { x: 1180, y: -10 },
+  archive: { x: 220, y: 520 }
+};
+
+const STATION_COLORS: Record<StationId, { pad: number; glow: number }> = {
+  board: { pad: 0x4f7bff, glow: 0x7aa0ff },
+  library: { pad: 0x54c8ff, glow: 0x8cdbff },
+  forge: { pad: 0xffa24a, glow: 0xffc180 },
+  terminal: { pad: 0x7dffb2, glow: 0xa6ffcf },
+  gate: { pad: 0xffd35a, glow: 0xffe28c },
+  archive: { pad: 0xd68cff, glow: 0xe8b3ff }
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function distance(a: Vec2, b: Vec2): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+function hashString(input: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function rngFromSeed(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = Math.imul(1664525, state) + 1013904223;
+    return (state >>> 0) / 4294967296;
+  };
+}
+
+function goldenSpiral(index: number, spacing: number): Vec2 {
+  const angle = index * 2.399963229728653;
+  const radius = spacing * Math.sqrt(index + 1);
+  return {
+    x: Math.cos(angle) * radius,
+    y: Math.sin(angle) * radius
+  };
+}
+
+function stageFromWrites(writes: number): number {
+  if (writes <= 0) {
+    return 0;
+  }
+  if (writes <= 2) {
+    return 1;
+  }
+  if (writes <= 5) {
+    return 2;
+  }
+  if (writes <= 10) {
+    return 3;
+  }
+  return 4;
+}
+
+function directionFromDelta(dx: number, dy: number): PatchlingDir {
+  if (Math.abs(dx) > Math.abs(dy)) {
+    return dx >= 0 ? "E" : "W";
+  }
+  return dy >= 0 ? "S" : "N";
+}
+
+export class ColonySimulation {
+  private host: HTMLDivElement;
+
+  private app: Application;
+
+  private layers: Layers;
+
+  private sprites: PatchlingSpriteSet | null = null;
+
+  private placeholderTexture: Texture | null = null;
+
+  private followHotspot = true;
+
+  private onChapterSaved?: (runId: string) => void;
+
+  private runStatus: RunStatus = "idle";
+
+  private runId = "pending";
+
+  private runConnected = false;
+
+  private chapterCount = 0;
+
+  private world: WorldState | null = null;
+
+  private chapters: ChapterSummary[] = [];
+
+  private knownChapterIds = new Set<string>();
+
+  private chaptersInitialized = false;
+
+  private camera: CameraState;
+
+  private stations = new Map<StationId, Station>();
+
+  private stationGlowUntil = new Map<StationId, number>();
+
+  private districtById = new Map<string, District>();
+
+  private buildingById = new Map<string, Building>();
+
+  private districtOrder: string[] = [];
+
+  private worldDirty = true;
+
+  private lastTouchedDistrictId: string | null = null;
+
+  private lastTouchedBuildingId: string | null = null;
+
+  private jobs: Job[] = [];
+
+  private jobsById = new Map<string, Job>();
+
+  private jobCounter = 0;
+
+  private agents = new Map<string, Agent>();
+
+  private agentCounter = 0;
+
+  private gateQueue: string[] = [];
+
+  private gateAssignments = new Map<string, number>();
+
+  private pulses: PulseFx[] = [];
+
+  private puffs: PuffFx[] = [];
+
+  private relics: Graphics[] = [];
+
+  private relicCount = 0;
+
+  private hotspot: { position: Vec2; expiresAt: number } | null = null;
+
+  private seenEventKeys = new Map<string, number>();
+
+  private seenEventOrder: string[] = [];
+
+  private eventTimes: number[] = [];
+
+  private eventsPerSecond = 0;
+
+  private statusText: Text;
+
+  private pathGraphic: Graphics;
+
+  private hotspotGraphic: Graphics;
+
+  constructor(host: HTMLDivElement, options: ColonySimulationOptions) {
+    this.host = host;
+    this.followHotspot = options.followHotspot;
+    if (options.onChapterSaved) {
+      this.onChapterSaved = options.onChapterSaved;
+    }
+
+    this.camera = {
+      x: INITIAL_CAMERA.x,
+      y: INITIAL_CAMERA.y,
+      targetX: INITIAL_CAMERA.x,
+      targetY: INITIAL_CAMERA.y,
+      scale: INITIAL_CAMERA.scale,
+      targetScale: INITIAL_CAMERA.scale,
+      dragging: false,
+      dragStart: { x: 0, y: 0 },
+      dragCameraStart: { x: 0, y: 0 },
+      followSuppressedUntil: 0
+    };
+
+    this.app = new Application({
+      antialias: true,
+      backgroundAlpha: 0,
+      resizeTo: host
+    });
+
+    const view = this.app.view as HTMLCanvasElement;
+    view.style.width = "100%";
+    view.style.height = "100%";
+    view.style.display = "block";
+    view.style.touchAction = "none";
+    host.appendChild(view);
+
+    this.layers = this.createLayers();
+    this.pathGraphic = new Graphics();
+    this.layers.pathLayer.addChild(this.pathGraphic);
+    this.hotspotGraphic = new Graphics();
+    this.layers.fxLayer.addChild(this.hotspotGraphic);
+    this.statusText = this.createHudText();
+    this.updateHudText();
+    this.bindCameraControls(view);
+
+    this.drawGround();
+    this.createStations();
+    this.spawnInitialAgents();
+
+    this.app.ticker.add((delta) => {
+      this.tick(delta);
+    });
+
+    void this.setAssetBase(options.assetBase);
+  }
+
+  destroy(): void {
+    this.app.ticker.stop();
+    this.app.destroy(true, true);
+    const view = this.app.view as HTMLCanvasElement;
+    if (this.host.contains(view)) {
+      this.host.removeChild(view);
+    }
+  }
+
+  setFollowHotspot(enabled: boolean): void {
+    this.followHotspot = enabled;
+  }
+
+  setConnection(connected: boolean, status: RunStatus, runId: string): void {
+    this.runConnected = connected;
+    this.runStatus = connected ? status : "idle";
+    this.runId = runId || this.runId;
+    this.updateHudText();
+  }
+
+  async setAssetBase(assetBase: string): Promise<void> {
+    this.sprites = await loadPatchlingSprites({ assetBase });
+    this.refreshAgentSprites();
+  }
+
+  ingestWorld(world: WorldState | null): void {
+    this.world = world;
+    this.chapterCount = world?.counters.chapters ?? this.chapterCount;
+    this.worldDirty = true;
+    this.updateHudText();
+  }
+
+  ingestChapters(chapters: ChapterSummary[]): void {
+    this.chapters = chapters;
+    if (!this.chaptersInitialized) {
+      for (const chapter of chapters) {
+        this.knownChapterIds.add(chapter.chapter_id);
+      }
+      this.chaptersInitialized = true;
+    } else {
+      for (const chapter of chapters) {
+        if (!this.knownChapterIds.has(chapter.chapter_id)) {
+          this.knownChapterIds.add(chapter.chapter_id);
+          this.onChapterSaved?.(chapter.run_id);
+        }
+      }
+    }
+    this.chapterCount = Math.max(this.chapterCount, chapters.length);
+    this.updateHudText();
+  }
+
+  ingestEvents(events: TelemetryEventV1[]): void {
+    const now = Date.now();
+    for (const event of events) {
+      if (!this.rememberEvent(event)) {
+        continue;
+      }
+      this.recordEventTime(now);
+      const seed = mapEventToJobSeed(event);
+      if (!seed) {
+        continue;
+      }
+      const job = this.createJobFromSeed(seed, now);
+      if (!this.districtById.has(job.districtId) || (job.buildingId && !this.buildingById.has(job.buildingId))) {
+        this.worldDirty = true;
+      }
+      this.jobs.push(job);
+      this.jobsById.set(job.id, job);
+
+      if (job.buildingId) {
+        this.lastTouchedBuildingId = job.buildingId;
+      }
+      this.lastTouchedDistrictId = job.districtId;
+      this.markHotspotForJob(job);
+    }
+
+    this.jobs.sort((a, b) => a.seed.seq - b.seed.seq);
+    if (this.jobs.length >= JOB_SPAWN_THRESHOLD && this.agents.size < MAX_AGENTS) {
+      this.spawnAgent();
+    }
+  }
+
+  private createLayers(): Layers {
+    const worldRoot = new Container();
+    const groundLayer = new Container();
+    const pathLayer = new Container();
+    const buildingsLayer = new Container();
+    const propsLayer = new Container();
+    const agentsLayer = new Container();
+    const fxLayer = new Container();
+    const uiWorldLayer = new Container();
+    const hudLayer = new Container();
+
+    worldRoot.addChild(groundLayer);
+    worldRoot.addChild(pathLayer);
+    worldRoot.addChild(buildingsLayer);
+    worldRoot.addChild(propsLayer);
+    worldRoot.addChild(agentsLayer);
+    worldRoot.addChild(fxLayer);
+    worldRoot.addChild(uiWorldLayer);
+
+    this.app.stage.addChild(worldRoot);
+    this.app.stage.addChild(hudLayer);
+
+    return {
+      worldRoot,
+      groundLayer,
+      pathLayer,
+      buildingsLayer,
+      propsLayer,
+      agentsLayer,
+      fxLayer,
+      uiWorldLayer,
+      hudLayer
+    };
+  }
+
+  private createHudText(): Text {
+    const label = new Text("", {
+      fill: 0xe6edff,
+      fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial",
+      fontSize: 12
+    });
+    label.position.set(12, 10);
+    this.layers.hudLayer.addChild(label);
+    return label;
+  }
+
+  private updateHudText(): void {
+    const status = this.runConnected ? this.runStatus : "disconnected";
+    const runId = this.runId;
+    const chapters = this.chapterCount;
+    const eps = this.eventsPerSecond.toFixed(1);
+    this.statusText.text = `Run: ${runId} • ${status} • chapters: ${chapters} • ${eps} ev/s`;
+  }
+
+  private tick(delta: number): void {
+    this.updateEventsPerSecond();
+    if (this.worldDirty) {
+      this.rebuildWorld();
+    }
+    this.assignJobs();
+    this.updateAgents(delta);
+    this.updateEffects();
+    this.updateHotspotGraphic();
+    this.applyCamera(delta);
+  }
+
+  private drawGround(): void {
+    if (this.layers.groundLayer.children.length > 0) {
+      return;
+    }
+    const ground = new Graphics();
+    ground.beginFill(0x0b1a10, 1);
+    ground.drawRect(-WORLD_HALF_SIZE, -WORLD_HALF_SIZE, WORLD_HALF_SIZE * 2, WORLD_HALF_SIZE * 2);
+    ground.endFill();
+    this.layers.groundLayer.addChild(ground);
+  }
+
+  private bindCameraControls(view: HTMLCanvasElement): void {
+    const onPointerDown = (event: PointerEvent) => {
+      this.camera.dragging = true;
+      this.camera.dragStart = { x: event.clientX, y: event.clientY };
+      this.camera.dragCameraStart = { x: this.camera.targetX, y: this.camera.targetY };
+      this.camera.followSuppressedUntil = Date.now() + 2000;
+    };
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (!this.camera.dragging) {
+        return;
+      }
+      const dx = event.clientX - this.camera.dragStart.x;
+      const dy = event.clientY - this.camera.dragStart.y;
+      const scale = this.camera.targetScale;
+      this.camera.targetX = this.camera.dragCameraStart.x - dx / scale;
+      this.camera.targetY = this.camera.dragCameraStart.y - dy / scale;
+    };
+
+    const endDrag = () => {
+      this.camera.dragging = false;
+      this.camera.followSuppressedUntil = Date.now() + 1200;
+    };
+
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const zoomFactor = event.deltaY < 0 ? 1.1 : 0.92;
+      const before = this.screenToWorld({ x: event.offsetX, y: event.offsetY });
+      const nextScale = clamp(this.camera.targetScale * zoomFactor, MIN_ZOOM, MAX_ZOOM);
+      this.camera.targetScale = nextScale;
+
+      const { width, height } = this.getScreenSize();
+      const nextX = before.x - (event.offsetX - width / 2) / nextScale;
+      const nextY = before.y - (event.offsetY - height / 2) / nextScale;
+      this.camera.targetX = nextX;
+      this.camera.targetY = nextY;
+      this.camera.followSuppressedUntil = Date.now() + 1600;
+    };
+
+    view.addEventListener("pointerdown", onPointerDown);
+    view.addEventListener("pointermove", onPointerMove);
+    view.addEventListener("pointerup", endDrag);
+    view.addEventListener("pointerleave", endDrag);
+    view.addEventListener("wheel", onWheel, { passive: false });
+  }
+
+  private getScreenSize(): { width: number; height: number } {
+    return {
+      width: this.app.screen.width,
+      height: this.app.screen.height
+    };
+  }
+
+  private screenToWorld(point: Vec2): Vec2 {
+    const { width, height } = this.getScreenSize();
+    return {
+      x: this.camera.x + (point.x - width / 2) / this.camera.scale,
+      y: this.camera.y + (point.y - height / 2) / this.camera.scale
+    };
+  }
+
+  private applyCamera(delta: number): void {
+    const now = Date.now();
+    if (this.hotspot && this.hotspot.expiresAt <= now) {
+      this.hotspot = null;
+    }
+
+    const followAllowed = this.followHotspot && now >= this.camera.followSuppressedUntil;
+    if (followAllowed && this.hotspot) {
+      const strength = 0.06;
+      this.camera.targetX = lerp(this.camera.targetX, this.hotspot.position.x, strength);
+      this.camera.targetY = lerp(this.camera.targetY, this.hotspot.position.y, strength);
+    }
+
+    const bound = WORLD_HALF_SIZE - 140;
+    this.camera.targetX = clamp(this.camera.targetX, -bound, bound);
+    this.camera.targetY = clamp(this.camera.targetY, -bound, bound);
+
+    const dt = clamp(delta / 60, 0.5, 2);
+    const ease = clamp(0.18 * dt, 0.05, 0.28);
+    this.camera.x = clamp(lerp(this.camera.x, this.camera.targetX, ease), -bound, bound);
+    this.camera.y = clamp(lerp(this.camera.y, this.camera.targetY, ease), -bound, bound);
+    this.camera.scale = lerp(this.camera.scale, this.camera.targetScale, ease * 0.9);
+
+    const { width, height } = this.getScreenSize();
+    const scale = this.camera.scale;
+    this.layers.worldRoot.scale.set(scale, scale);
+    this.layers.worldRoot.position.set(width / 2 - this.camera.x * scale, height / 2 - this.camera.y * scale);
+    this.layers.hudLayer.position.set(0, 0);
+  }
+
+  private createStations(): void {
+    this.stations.clear();
+    const labels: Record<StationId, string> = {
+      board: "Board",
+      library: "Library",
+      forge: "Forge",
+      terminal: "Terminal",
+      gate: "Gate",
+      archive: "Archive"
+    };
+
+    (Object.keys(STATION_LAYOUT) as StationId[]).forEach((stationId) => {
+      const station = this.createStation(stationId, labels[stationId]);
+      this.stations.set(stationId, station);
+      this.layers.buildingsLayer.addChild(station.container);
+    });
+  }
+
+  private createStation(id: StationId, label: string): Station {
+    const position = STATION_LAYOUT[id];
+    const colors = STATION_COLORS[id];
+    const container = new Container();
+    container.position.set(position.x, position.y);
+
+    const glow = new Graphics();
+    glow.beginFill(colors.glow, 0.12);
+    glow.drawCircle(0, 0, 92);
+    glow.endFill();
+    container.addChild(glow);
+
+    const pad = new Graphics();
+    pad.beginFill(colors.pad, 0.42);
+    pad.lineStyle(2, colors.glow, 0.75);
+    pad.drawRoundedRect(-52, -44, 104, 88, 16);
+    pad.endFill();
+    container.addChild(pad);
+
+    const ring = new Graphics();
+    ring.lineStyle(2, colors.glow, 0.6);
+    ring.drawCircle(0, 0, 58);
+    container.addChild(ring);
+
+    const title = new Text(label, {
+      fill: 0xe6edff,
+      fontFamily: "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial",
+      fontSize: 12,
+      fontWeight: "600"
+    });
+    title.anchor.set(0.5, 0);
+    title.position.set(0, 54);
+    container.addChild(title);
+
+    const queueSpots =
+      id === "gate"
+        ? Array.from({ length: 6 }, (_, index) => ({
+            x: position.x - 120 - index * 32,
+            y: position.y + 94
+          }))
+        : undefined;
+
+    const baseStation = {
+      id,
+      label,
+      position,
+      radius: 64,
+      container,
+      pad,
+      glow
+    };
+    return queueSpots ? { ...baseStation, queueSpots } : baseStation;
+  }
+
+  private getPlaceholderTexture(): Texture {
+    if (this.placeholderTexture) {
+      return this.placeholderTexture;
+    }
+    const g = new Graphics();
+    g.beginFill(0x7dffb2, 1);
+    g.drawCircle(16, 16, 16);
+    g.endFill();
+    this.placeholderTexture = this.app.renderer.generateTexture(g);
+    g.destroy();
+    return this.placeholderTexture;
+  }
+
+  private createAgentSprite(): AnimatedSprite {
+    const fallback = this.getPlaceholderTexture();
+    const spriteSet = this.sprites;
+    const usingSprites = spriteSet?.mode === "sprites";
+    const idleSouth = usingSprites && spriteSet ? spriteSet.animations.idle.S : [fallback];
+    const sprite = new AnimatedSprite(idleSouth);
+    sprite.anchor.set(0.5, 1);
+    sprite.position.set(0, 0);
+    sprite.animationSpeed = 0.1;
+    sprite.play();
+    const scale = usingSprites ? 0.72 : 1.2;
+    sprite.scale.set(scale, scale);
+    sprite.tint = usingSprites ? 0xffffff : 0x7dffb2;
+    return sprite;
+  }
+
+  private randomAround(center: Vec2, radius: number): Vec2 {
+    const angle = Math.random() * Math.PI * 2;
+    const r = radius * (0.25 + Math.random() * 0.75);
+    return {
+      x: center.x + Math.cos(angle) * r,
+      y: center.y + Math.sin(angle) * r
+    };
+  }
+
+  private updateAgentDirection(agent: Agent): void {
+    const dx = agent.targetPos.x - agent.pos.x;
+    const dy = agent.targetPos.y - agent.pos.y;
+    if (Math.abs(dx) < 0.5 && Math.abs(dy) < 0.5) {
+      return;
+    }
+    agent.dir = directionFromDelta(dx, dy);
+  }
+
+  private animationForState(agent: Agent): PatchlingAction {
+    if (agent.payload === "block" || agent.state === "carry") {
+      return "carry";
+    }
+    if (agent.state === "walk") {
+      return "walk";
+    }
+    return "idle";
+  }
+
+  private updateAgentAnimation(agent: Agent): void {
+    this.updateAgentDirection(agent);
+    const action = this.animationForState(agent);
+    const dir = agent.dir;
+    const spriteSet = this.sprites;
+    const useSprites = spriteSet?.mode === "sprites";
+    const modeKey = useSprites ? "sprites" : "placeholder";
+    const animKey = `${modeKey}:${action}:${dir}:${agent.state}:${agent.payload}`;
+    if (agent.animKey === animKey) {
+      return;
+    }
+    const textures = useSprites && spriteSet ? spriteSet.animations[action][dir] : [this.getPlaceholderTexture()];
+    agent.sprite.textures = textures;
+    agent.sprite.animationSpeed = action === "idle" ? 0.08 : 0.16;
+    if (!agent.sprite.playing) {
+      agent.sprite.play();
+    }
+    if (useSprites) {
+      agent.sprite.tint = 0xffffff;
+    } else {
+      let tint = 0x7dffb2;
+      if (agent.payload === "block") {
+        tint = 0xffc180;
+      } else if (agent.state === "interact") {
+        tint = 0xe8b3ff;
+      } else if (agent.state === "walk") {
+        tint = 0x7db4ff;
+      }
+      agent.sprite.tint = tint;
+    }
+    agent.animState = action;
+    agent.animDir = dir;
+    agent.animKey = animKey;
+  }
+
+  private setAgentState(agent: Agent, state: Agent["state"], payload: Agent["payload"]): void {
+    agent.state = state;
+    agent.payload = payload;
+    if (agent.block) {
+      agent.block.visible = payload === "block";
+      agent.block.tint = payload === "block" ? 0xffc180 : 0xffffff;
+    }
+    this.updateAgentAnimation(agent);
+  }
+
+  private resetAgentDisplay(agent: Agent): void {
+    const children = [agent.shadow, agent.sprite, agent.block, agent.bubble].filter(
+      (child): child is NonNullable<typeof child> => Boolean(child)
+    );
+    agent.container.removeChildren();
+    for (const child of children) {
+      agent.container.addChild(child);
+    }
+    agent.container.position.set(agent.pos.x, agent.pos.y);
+  }
+
+  private refreshAgentSprites(): void {
+    for (const agent of this.agents.values()) {
+      agent.container.removeChild(agent.sprite);
+      agent.sprite.destroy();
+      agent.sprite = this.createAgentSprite();
+      agent.animState = "walk";
+      agent.animDir = agent.animDir === "S" ? "N" : "S";
+      agent.animKey = "";
+      this.resetAgentDisplay(agent);
+      this.updateAgentAnimation(agent);
+    }
+  }
+
+  private spawnInitialAgents(): void {
+    for (let i = 0; i < BASE_AGENT_COUNT; i += 1) {
+      this.spawnAgent();
+    }
+  }
+
+  private spawnAgent(): Agent {
+    const board = this.stations.get("board");
+    const base = board?.position ?? { x: 0, y: 0 };
+    const spawnPos = this.randomAround(base, 140);
+    const agent = this.createAgent(spawnPos);
+    this.agents.set(agent.id, agent);
+    return agent;
+  }
+
+  private createAgent(spawnPos: Vec2): Agent {
+    this.agentCounter += 1;
+    const id = `patchling-${this.agentCounter}`;
+    const board = this.stations.get("board");
+    const base = board?.position ?? { x: 0, y: 0 };
+    const container = new Container();
+    container.position.set(spawnPos.x, spawnPos.y);
+
+    const shadow = new Graphics();
+    shadow.beginFill(0x05090f, 0.55);
+    shadow.drawEllipse(0, 8, 18, 9);
+    shadow.endFill();
+    shadow.zIndex = 0;
+
+    const sprite = this.createAgentSprite();
+    sprite.zIndex = 2;
+
+    const block = new Graphics();
+    block.beginFill(0xffc180, 0.9);
+    block.lineStyle(2, 0xffe6c8, 0.8);
+    block.drawRoundedRect(-10, -12, 20, 20, 6);
+    block.endFill();
+    block.position.set(0, -46);
+    block.visible = false;
+    block.zIndex = 3;
+
+    container.sortableChildren = true;
+    container.addChild(shadow);
+    container.addChild(sprite);
+    container.addChild(block);
+
+    this.layers.agentsLayer.addChild(container);
+
+    const agent: Agent = {
+      id,
+      role: "builder",
+      state: "idle",
+      dir: "S",
+      animState: "walk",
+      animDir: "N",
+      animKey: "",
+      pos: { ...spawnPos },
+      targetPos: this.randomAround(base, 180),
+      speed: 96,
+      payload: "none",
+      jobId: undefined,
+      anchorStationId: "board",
+      container,
+      sprite,
+      shadow,
+      block
+    };
+
+    this.resetAgentDisplay(agent);
+    this.updateAgentAnimation(agent);
+    return agent;
+  }
+
+  private districtRadius(regionId: string): number {
+    const region = this.world?.regions[regionId];
+    if (!region) {
+      return 92;
+    }
+    const fileFactor = Math.sqrt(region.file_count + 1) * 6.5;
+    const touchFactor = Math.log10(region.touch_count + 10) * 18;
+    return clamp(78 + fileFactor + touchFactor, 82, 168);
+  }
+
+  private ensureDistrict(regionId: string, index: number): District {
+    const existing = this.districtById.get(regionId);
+    const radius = this.districtRadius(regionId);
+    if (existing) {
+      existing.radius = radius;
+      existing.index = index;
+      existing.ring.position.set(existing.center.x, existing.center.y);
+      this.drawDistrict(existing);
+      return existing;
+    }
+
+    const ring = new Graphics();
+    const center = this.positionDistrict(regionId, index);
+    ring.position.set(center.x, center.y);
+    this.layers.buildingsLayer.addChild(ring);
+
+    const district: District = {
+      id: regionId,
+      index,
+      center,
+      radius,
+      ring
+    };
+    this.drawDistrict(district);
+    this.districtById.set(regionId, district);
+    return district;
+  }
+
+  private positionDistrict(regionId: string, index: number): Vec2 {
+    const seedIndex = hashString(regionId) % 20;
+    const seedPos = goldenSpiral(seedIndex, DISTRICT_SPACING);
+    const offset = goldenSpiral(index, DISTRICT_SPACING * 0.25);
+    const bound = WORLD_HALF_SIZE - 180;
+    const centerX = INITIAL_CAMERA.x;
+    const centerY = INITIAL_CAMERA.y;
+    const rawX = centerX + seedPos.x * 0.9 + offset.x * 0.25;
+    const rawY = centerY + seedPos.y * 0.9 + offset.y * 0.25;
+    return {
+      x: clamp(rawX, -bound, bound),
+      y: clamp(rawY, -bound, bound)
+    };
+  }
+
+  private drawDistrict(district: District): void {
+    const { ring, radius, id } = district;
+    const seed = hashString(id);
+    const tint = 0x1a2d52 + (seed % 0x003333);
+    ring.clear();
+    ring.beginFill(tint, 0.58);
+    ring.lineStyle(2, 0x6ba3ff, 0.7);
+    ring.drawCircle(0, 0, radius);
+    ring.endFill();
+
+    ring.lineStyle(1, 0x9bc8ff, 0.4);
+    ring.drawCircle(0, 0, radius * 0.68);
+  }
+
+  private ensureDistrictForId(districtId: string): District {
+    const existing = this.districtById.get(districtId);
+    if (existing) {
+      return existing;
+    }
+    const knownIndex = this.districtOrder.indexOf(districtId);
+    const index = knownIndex >= 0 ? knownIndex : this.districtById.size;
+    return this.ensureDistrict(districtId, index);
+  }
+
+  private ensureBuilding(buildingId: string, districtId: string, baseWrites: number, ts: string): Building {
+    const existing = this.buildingById.get(buildingId);
+    const writes = Math.max(baseWrites, existing?.writes ?? 0);
+    if (existing) {
+      existing.writes = writes;
+      existing.stage = stageFromWrites(writes);
+      existing.lastTs = ts;
+      this.drawBuilding(existing);
+      return existing;
+    }
+
+    const district = this.ensureDistrictForId(districtId);
+    const position = this.positionBuilding(buildingId, district);
+    const sprite = new Graphics();
+    sprite.position.set(position.x, position.y);
+    this.layers.buildingsLayer.addChild(sprite);
+
+    const building: Building = {
+      id: buildingId,
+      districtId,
+      position,
+      writes,
+      stage: stageFromWrites(writes),
+      sprite,
+      lastTs: ts
+    };
+    this.drawBuilding(building);
+    this.buildingById.set(buildingId, building);
+    return building;
+  }
+
+  private positionBuilding(buildingId: string, district: District): Vec2 {
+    const seed = hashString(buildingId);
+    const rnd = rngFromSeed(seed);
+    const angle = rnd() * Math.PI * 2;
+    const radius = BUILDING_MIN_RADIUS + rnd() * (BUILDING_MAX_RADIUS - BUILDING_MIN_RADIUS);
+    return {
+      x: district.center.x + Math.cos(angle) * radius,
+      y: district.center.y + Math.sin(angle) * radius
+    };
+  }
+
+  private drawBuilding(building: Building): void {
+    const { sprite, stage, id } = building;
+    const seed = hashString(id);
+    const tint = 0x2d4f7d + (seed % 0x002222);
+    const width = 26 + stage * 8;
+    const height = 18 + stage * 11;
+
+    sprite.clear();
+    sprite.beginFill(0x0e1628, 0.5);
+    sprite.drawEllipse(0, 6, width * 0.55, 10);
+    sprite.endFill();
+
+    sprite.beginFill(tint, 0.92);
+    sprite.lineStyle(2, 0x9bc8ff, 0.6);
+    sprite.drawRoundedRect(-width / 2, -height, width, height, 8);
+    sprite.endFill();
+
+    if (stage >= 3) {
+      sprite.beginFill(0xcfe6ff, 0.7);
+      sprite.drawRoundedRect(-width * 0.15, -height * 0.85, width * 0.3, height * 0.24, 5);
+      sprite.endFill();
+    }
+
+    if (stage >= 4) {
+      sprite.lineStyle(2, 0x6ba3ff, 0.8);
+      sprite.moveTo(0, -height - 10);
+      sprite.lineTo(0, -height - 34);
+      sprite.beginFill(0x9bc8ff, 0.9);
+      sprite.drawCircle(0, -height - 38, 5);
+      sprite.endFill();
+    }
+  }
+
+  private bumpBuildingWrites(buildingId: string, districtId: string, ts: string): void {
+    const building = this.ensureBuilding(buildingId, districtId, 0, ts);
+    building.writes += 1;
+    building.stage = stageFromWrites(building.writes);
+    building.lastTs = ts;
+    this.drawBuilding(building);
+  }
+
+  private rebuildWorld(): void {
+    const regionIds = new Set<string>();
+    if (this.world) {
+      for (const regionId of Object.keys(this.world.regions)) {
+        regionIds.add(regionId);
+      }
+    }
+    for (const job of this.jobs) {
+      regionIds.add(job.districtId);
+    }
+    for (const building of this.buildingById.values()) {
+      regionIds.add(building.districtId);
+    }
+
+    const ordered = [...regionIds].sort();
+    const limited = ordered.slice(0, MAX_DISTRICTS);
+    this.districtOrder = limited;
+
+    limited.forEach((regionId, index) => {
+      this.ensureDistrict(regionId, index);
+    });
+
+    let buildingCount = 0;
+    const worldFiles = this.world ? Object.values(this.world.files) : [];
+    worldFiles.sort((a, b) => a.id.localeCompare(b.id));
+    for (const file of worldFiles) {
+      if (buildingCount >= MAX_BUILDINGS) {
+        break;
+      }
+      const districtId = file.region_id ?? "region.unknown";
+      if (!this.districtById.has(districtId)) {
+        this.ensureDistrictForId(districtId);
+      }
+      this.ensureBuilding(file.id, districtId, file.touch_count, file.last_ts);
+      buildingCount += 1;
+    }
+
+    for (const job of this.jobs) {
+      if (buildingCount >= MAX_BUILDINGS) {
+        break;
+      }
+      if (!this.districtById.has(job.districtId)) {
+        this.ensureDistrictForId(job.districtId);
+      }
+      if (job.buildingId && !this.buildingById.has(job.buildingId)) {
+        this.ensureBuilding(job.buildingId, job.districtId, 0, job.seed.ts);
+        buildingCount += 1;
+      }
+    }
+
+    this.drawPaths(limited);
+    this.worldDirty = false;
+  }
+
+  private drawPaths(activeDistrictIds: string[]): void {
+    this.pathGraphic.clear();
+    const baseColor = 0x6c5a2f;
+    const edgeColor = 0xb9984d;
+    const drawSegment = (from: Vec2, to: Vec2, alpha = 0.32) => {
+      this.pathGraphic.lineStyle(14, baseColor, alpha, 0.5);
+      this.pathGraphic.moveTo(from.x, from.y);
+      this.pathGraphic.lineTo(to.x, to.y);
+      this.pathGraphic.lineStyle(4, edgeColor, alpha * 0.9, 0.5);
+      this.pathGraphic.moveTo(from.x, from.y);
+      this.pathGraphic.lineTo(to.x, to.y);
+    };
+
+    const board = this.stations.get("board");
+    if (board) {
+      for (const station of this.stations.values()) {
+        if (station.id === "board") {
+          continue;
+        }
+        drawSegment(board.position, station.position, 0.38);
+      }
+    }
+
+    const districtLimit = activeDistrictIds.slice(0, 80);
+    for (const districtId of districtLimit) {
+      const district = this.districtById.get(districtId);
+      if (!district) {
+        continue;
+      }
+      const station = this.nearestStation(district.center);
+      if (station) {
+        drawSegment(station.position, district.center, 0.24);
+      }
+    }
+  }
+
+  private nearestStation(point: Vec2): Station | null {
+    let best: Station | null = null;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (const station of this.stations.values()) {
+      const d = distance(point, station.position);
+      if (d < bestDistance) {
+        bestDistance = d;
+        best = station;
+      }
+    }
+    return best;
+  }
+
+  private recomputeGateAssignments(): void {
+    const gate = this.stations.get("gate");
+    const spots = gate?.queueSpots ?? [];
+    this.gateAssignments.clear();
+    const nextQueue: string[] = [];
+    for (const agentId of this.gateQueue) {
+      if (!this.agents.has(agentId)) {
+        continue;
+      }
+      const index = Math.min(nextQueue.length, Math.max(0, spots.length - 1));
+      nextQueue.push(agentId);
+      this.gateAssignments.set(agentId, index);
+    }
+    this.gateQueue = nextQueue;
+  }
+
+  private enqueueGate(agentId: string): void {
+    if (!this.gateQueue.includes(agentId)) {
+      this.gateQueue.push(agentId);
+      this.recomputeGateAssignments();
+    }
+  }
+
+  private dequeueGate(agentId: string): void {
+    const next = this.gateQueue.filter((id) => id !== agentId);
+    if (next.length !== this.gateQueue.length) {
+      this.gateQueue = next;
+      this.recomputeGateAssignments();
+    }
+  }
+
+  private gateTarget(agentId: string): Vec2 | null {
+    const gate = this.stations.get("gate");
+    if (!gate) {
+      return null;
+    }
+    const spots = gate.queueSpots;
+    if (!spots || spots.length === 0) {
+      return gate.position;
+    }
+    const index = this.gateAssignments.get(agentId) ?? 0;
+    const spot = spots[Math.min(index, spots.length - 1)];
+    return spot ?? gate.position;
+  }
+
+  private assignJobs(): void {
+    const idleAgents = [...this.agents.values()].filter((agent) => !agent.jobId);
+    if (idleAgents.length === 0) {
+      return;
+    }
+    const availableJobs = this.jobs.filter((job) => !job.assignedAgentId && job.step !== "done");
+    if (availableJobs.length === 0) {
+      return;
+    }
+    availableJobs.sort((a, b) => a.seed.seq - b.seed.seq);
+    const now = Date.now();
+    for (const job of availableJobs) {
+      const agent = idleAgents.shift();
+      if (!agent) {
+        break;
+      }
+      this.beginJob(agent, job, now);
+    }
+  }
+
+  private beginJob(agent: Agent, job: Job, now: number): void {
+    job.assignedAgentId = agent.id;
+    job.step = "to_station";
+    job.stepStartedAt = now;
+    agent.jobId = job.id;
+    agent.anchorStationId = job.stationId;
+    if (job.stationId === "gate") {
+      this.enqueueGate(agent.id);
+    }
+    const station = this.stations.get(job.stationId);
+    agent.targetPos = station ? { ...station.position } : { ...agent.pos };
+    this.setAgentState(agent, "walk", "none");
+  }
+
+  private jobStationTarget(agent: Agent, job: Job): Vec2 {
+    if (job.stationId === "gate") {
+      return this.gateTarget(agent.id) ?? this.stations.get("gate")?.position ?? { ...agent.pos };
+    }
+    const station = this.stations.get(job.stationId);
+    return station ? station.position : { ...agent.pos };
+  }
+
+  private jobTargetPosition(job: Job): Vec2 {
+    const district = this.ensureDistrictForId(job.districtId);
+    if (job.buildingId) {
+      const building = this.ensureBuilding(job.buildingId, job.districtId, 0, job.seed.ts);
+      return building.position;
+    }
+    return district.center;
+  }
+
+  private moveAgentTowards(agent: Agent, target: Vec2, stepDistance: number): boolean {
+    agent.targetPos = { ...target };
+    const dx = target.x - agent.pos.x;
+    const dy = target.y - agent.pos.y;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist <= Math.max(2, stepDistance)) {
+      agent.pos = { ...target };
+      agent.container.position.set(agent.pos.x, agent.pos.y);
+      this.updateAgentAnimation(agent);
+      return true;
+    }
+    const nx = dx / dist;
+    const ny = dy / dist;
+    agent.pos = {
+      x: agent.pos.x + nx * stepDistance,
+      y: agent.pos.y + ny * stepDistance
+    };
+    agent.container.position.set(agent.pos.x, agent.pos.y);
+    this.updateAgentAnimation(agent);
+    return false;
+  }
+
+  private interactionDurationMs(type: JobType): number {
+    switch (type) {
+      case "FILE_WRITE":
+        return 1400;
+      case "APPROVAL_WAIT":
+        return 2800;
+      case "TURN_COMPLETE":
+        return 1200;
+      case "TURN_START":
+        return 900;
+      case "TEST_FAIL":
+        return 1400;
+      case "TEST_PASS":
+        return 1000;
+      case "TEST_RUN":
+        return 1000;
+      case "FILE_READ":
+        return 900;
+      case "TOOL_RUN":
+        return 950;
+      default:
+        return 1000;
+    }
+  }
+
+  private anchorPointForAgent(agent: Agent): Vec2 {
+    if (agent.anchorStationId) {
+      const station = this.stations.get(agent.anchorStationId);
+      if (station) {
+        return station.position;
+      }
+    }
+    if (this.lastTouchedDistrictId) {
+      const district = this.districtById.get(this.lastTouchedDistrictId);
+      if (district) {
+        return district.center;
+      }
+    }
+    return this.stations.get("board")?.position ?? { x: 0, y: 0 };
+  }
+
+  private updateAgents(delta: number): void {
+    const now = Date.now();
+    const dt = clamp(delta / 60, 0.6, 2.2);
+    const approvalActive = this.jobs.some((job) => job.type === "APPROVAL_WAIT" && job.step !== "done");
+    const speedFactor = approvalActive ? 0.86 : 1;
+    const completedJobIds = new Set<string>();
+
+    for (const agent of this.agents.values()) {
+      const job = agent.jobId ? this.jobsById.get(agent.jobId) : undefined;
+      if (!job || job.step === "done") {
+        agent.jobId = undefined;
+        this.updateAgentIdle(agent, dt, speedFactor);
+        continue;
+      }
+      this.updateAgentJob(agent, job, now, dt, speedFactor, completedJobIds);
+    }
+
+    if (completedJobIds.size > 0) {
+      this.pruneCompletedJobs(completedJobIds);
+    }
+    this.recomputeGateAssignments();
+  }
+
+  private updateAgentIdle(agent: Agent, dt: number, speedFactor: number): void {
+    const anchor = this.anchorPointForAgent(agent);
+    const stepDistance = agent.speed * dt * speedFactor * 0.55;
+    const toTarget = distance(agent.pos, agent.targetPos);
+    if (toTarget < 10) {
+      agent.targetPos = this.randomAround(anchor, 200);
+    }
+    const shouldMove = distance(agent.pos, agent.targetPos) > 14;
+    if (!shouldMove) {
+      this.setAgentState(agent, "idle", "none");
+      agent.container.position.set(agent.pos.x, agent.pos.y);
+      return;
+    }
+    this.setAgentState(agent, "walk", "none");
+    this.moveAgentTowards(agent, agent.targetPos, stepDistance);
+  }
+
+  private updateAgentJob(
+    agent: Agent,
+    job: Job,
+    now: number,
+    dt: number,
+    speedFactor: number,
+    completedJobIds: Set<string>
+  ): void {
+    const stepDistance = agent.speed * dt * speedFactor;
+    switch (job.step) {
+      case "to_station": {
+        const stationTarget = this.jobStationTarget(agent, job);
+        this.setAgentState(agent, "walk", agent.payload);
+        const reached = this.moveAgentTowards(agent, stationTarget, stepDistance);
+        if (reached) {
+          this.handleStationArrival(agent, job);
+          const fileJob = job.type === "FILE_READ" || job.type === "FILE_WRITE";
+          job.step = fileJob ? "to_target" : "interact";
+          job.stepStartedAt = now;
+        }
+        break;
+      }
+      case "to_target": {
+        const target = this.jobTargetPosition(job);
+        const carryPayload = agent.payload === "block" ? "block" : "none";
+        const state = carryPayload === "block" ? "carry" : "walk";
+        this.setAgentState(agent, state, carryPayload);
+        const reached = this.moveAgentTowards(agent, target, stepDistance);
+        if (reached) {
+          job.step = "interact";
+          job.stepStartedAt = now;
+        }
+        break;
+      }
+      case "interact": {
+        this.setAgentState(agent, "interact", agent.payload);
+        if (now - job.stepStartedAt >= this.interactionDurationMs(job.type)) {
+          this.completeJob(agent, job, now, completedJobIds);
+        }
+        break;
+      }
+      case "done":
+      default: {
+        agent.jobId = undefined;
+        this.updateAgentIdle(agent, dt, speedFactor);
+        break;
+      }
+    }
+  }
+
+  private handleStationArrival(agent: Agent, job: Job): void {
+    this.pingStation(job.stationId);
+    if (job.type === "FILE_WRITE") {
+      this.setAgentState(agent, "carry", "block");
+    }
+  }
+
+  private completeJob(agent: Agent, job: Job, now: number, completedJobIds: Set<string>): void {
+    const station = this.stations.get(job.stationId);
+    const stationPos = station?.position;
+    const district = this.ensureDistrictForId(job.districtId);
+    const districtPos = district.center;
+    const buildingPos = job.buildingId ? this.jobTargetPosition(job) : districtPos;
+
+    const pulse = (pos: Vec2, color: number) => this.addPulse(pos, color, 1100);
+    const puff = (pos: Vec2, color: number) => this.addPuff(pos, color, 1300);
+
+    switch (job.type) {
+      case "FILE_WRITE": {
+        if (job.buildingId) {
+          this.bumpBuildingWrites(job.buildingId, job.districtId, job.seed.ts);
+          this.lastTouchedBuildingId = job.buildingId;
+        }
+        this.lastTouchedDistrictId = job.districtId;
+        if (stationPos) {
+          pulse(stationPos, 0xffc180);
+        }
+        pulse(buildingPos, 0xffe1b8);
+        puff(buildingPos, 0xffa24a);
+        break;
+      }
+      case "FILE_READ": {
+        if (stationPos) {
+          pulse(stationPos, 0x8cdbff);
+        }
+        pulse(districtPos, 0x7db4ff);
+        break;
+      }
+      case "TEST_PASS": {
+        if (stationPos) {
+          pulse(stationPos, 0x7dffb2);
+        }
+        break;
+      }
+      case "TEST_FAIL": {
+        if (stationPos) {
+          pulse(stationPos, 0xff7a7a);
+          puff(stationPos, 0xff7a7a);
+        }
+        const lastBuilding = this.lastTouchedBuildingId ? this.buildingById.get(this.lastTouchedBuildingId) : undefined;
+        const lastDistrict = this.lastTouchedDistrictId ? this.districtById.get(this.lastTouchedDistrictId) : undefined;
+        const impactPos = lastBuilding?.position ?? lastDistrict?.center ?? districtPos;
+        puff(impactPos, 0xff4d4d);
+        break;
+      }
+      case "TEST_RUN":
+      case "TOOL_RUN": {
+        if (stationPos) {
+          pulse(stationPos, 0x9bc8ff);
+        }
+        break;
+      }
+      case "APPROVAL_WAIT": {
+        if (stationPos) {
+          pulse(stationPos, 0xffd35a);
+        }
+        this.dequeueGate(agent.id);
+        break;
+      }
+      case "TURN_START": {
+        if (stationPos) {
+          pulse(stationPos, 0x7aa0ff);
+        }
+        break;
+      }
+      case "TURN_COMPLETE": {
+        if (stationPos) {
+          pulse(stationPos, 0xe8b3ff);
+        }
+        this.createRelic();
+        break;
+      }
+      default:
+        break;
+    }
+
+    job.step = "done";
+    job.stepStartedAt = now;
+    completedJobIds.add(job.id);
+    agent.jobId = undefined;
+    agent.payload = "none";
+    this.setAgentState(agent, "idle", "none");
+    const anchor = this.anchorPointForAgent(agent);
+    agent.targetPos = this.randomAround(anchor, 200);
+    agent.container.position.set(agent.pos.x, agent.pos.y);
+  }
+
+  private pruneCompletedJobs(completedJobIds: Set<string>): void {
+    for (const id of completedJobIds) {
+      this.jobsById.delete(id);
+    }
+    this.jobs = this.jobs.filter((job) => !completedJobIds.has(job.id));
+  }
+
+  private pingStation(id: StationId): void {
+    const station = this.stations.get(id);
+    if (!station) {
+      return;
+    }
+    const now = Date.now();
+    this.stationGlowUntil.set(id, now + 1200);
+    this.addPulse(station.position, STATION_COLORS[id].glow, 950);
+  }
+
+  private addPulse(position: Vec2, color: number, ttlMs: number): void {
+    const fx: PulseFx = {
+      id: `pulse:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`,
+      position: { ...position },
+      color,
+      ttlMs,
+      startedAt: Date.now(),
+      graphic: new Graphics()
+    };
+    this.layers.fxLayer.addChild(fx.graphic);
+    this.pulses.push(fx);
+    while (this.pulses.length > MAX_PULSES) {
+      const oldest = this.pulses.shift();
+      if (oldest) {
+        this.layers.fxLayer.removeChild(oldest.graphic);
+        oldest.graphic.destroy();
+      }
+    }
+  }
+
+  private addPuff(position: Vec2, color: number, ttlMs: number): void {
+    const fx: PuffFx = {
+      id: `puff:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`,
+      position: { ...position },
+      color,
+      ttlMs,
+      startedAt: Date.now(),
+      graphic: new Graphics()
+    };
+    this.layers.fxLayer.addChild(fx.graphic);
+    this.puffs.push(fx);
+    while (this.puffs.length > MAX_PUFFS) {
+      const oldest = this.puffs.shift();
+      if (oldest) {
+        this.layers.fxLayer.removeChild(oldest.graphic);
+        oldest.graphic.destroy();
+      }
+    }
+  }
+
+  private createRelic(): void {
+    const archive = this.stations.get("archive");
+    if (!archive) {
+      return;
+    }
+    this.relicCount += 1;
+    const index = this.relicCount;
+    const angle = index * 0.85;
+    const radius = 86 + Math.sqrt(index) * 10;
+    const position = {
+      x: archive.position.x + Math.cos(angle) * radius,
+      y: archive.position.y + Math.sin(angle) * radius * 0.7
+    };
+
+    const relic = new Graphics();
+    relic.position.set(position.x, position.y);
+    relic.beginFill(0xe8b3ff, 0.9);
+    relic.lineStyle(2, 0xffffff, 0.75);
+    relic.moveTo(0, -12);
+    relic.lineTo(10, 0);
+    relic.lineTo(0, 12);
+    relic.lineTo(-10, 0);
+    relic.closePath();
+    relic.endFill();
+    this.layers.propsLayer.addChild(relic);
+    this.relics.push(relic);
+
+    const maxRelics = 80;
+    while (this.relics.length > maxRelics) {
+      const oldest = this.relics.shift();
+      if (oldest) {
+        this.layers.propsLayer.removeChild(oldest);
+        oldest.destroy();
+      }
+    }
+  }
+
+  private updateEffects(): void {
+    const now = Date.now();
+
+    const nextPulses: PulseFx[] = [];
+    for (const pulse of this.pulses) {
+      const elapsed = now - pulse.startedAt;
+      const progress = elapsed / pulse.ttlMs;
+      if (progress >= 1) {
+        this.layers.fxLayer.removeChild(pulse.graphic);
+        pulse.graphic.destroy();
+        continue;
+      }
+      const radius = 14 + progress * 62;
+      const alpha = clamp(1 - progress, 0, 1) * 0.72;
+      pulse.graphic.clear();
+      pulse.graphic.lineStyle(3, pulse.color, alpha);
+      pulse.graphic.drawCircle(pulse.position.x, pulse.position.y, radius);
+      nextPulses.push(pulse);
+    }
+    this.pulses = nextPulses;
+
+    const nextPuffs: PuffFx[] = [];
+    for (const puff of this.puffs) {
+      const elapsed = now - puff.startedAt;
+      const progress = elapsed / puff.ttlMs;
+      if (progress >= 1) {
+        this.layers.fxLayer.removeChild(puff.graphic);
+        puff.graphic.destroy();
+        continue;
+      }
+      const radius = 18 + progress * 48;
+      const alpha = clamp(1 - progress, 0, 1) * 0.45;
+      puff.graphic.clear();
+      puff.graphic.beginFill(puff.color, alpha * 0.6);
+      puff.graphic.drawCircle(puff.position.x, puff.position.y, radius * 0.55);
+      puff.graphic.endFill();
+      puff.graphic.lineStyle(2, puff.color, alpha);
+      puff.graphic.drawCircle(puff.position.x, puff.position.y, radius);
+      nextPuffs.push(puff);
+    }
+    this.puffs = nextPuffs;
+
+    for (const station of this.stations.values()) {
+      const until = this.stationGlowUntil.get(station.id);
+      if (!until || until <= now) {
+        station.glow.alpha = 0.12;
+        if (until && until <= now) {
+          this.stationGlowUntil.delete(station.id);
+        }
+        continue;
+      }
+      const remaining = until - now;
+      const alpha = 0.12 + clamp(remaining / 1200, 0, 1) * 0.2;
+      station.glow.alpha = alpha;
+    }
+  }
+
+  private updateHotspotGraphic(): void {
+    const now = Date.now();
+    const hotspot = this.hotspot && this.hotspot.expiresAt > now ? this.hotspot : null;
+    this.hotspotGraphic.clear();
+    if (!hotspot) {
+      return;
+    }
+    const ttl = hotspot.expiresAt - now;
+    const life = clamp(ttl / HOTSPOT_LINGER_MS, 0.05, 1);
+    const pulse = Math.sin(now / 220) * 6;
+    const radius = 32 + pulse;
+    const alpha = life * 0.55;
+    this.hotspotGraphic.lineStyle(2, 0x9bc8ff, alpha);
+    this.hotspotGraphic.drawCircle(hotspot.position.x, hotspot.position.y, radius);
+  }
+
+  private rememberEvent(event: TelemetryEventV1): boolean {
+    const key = `${event.run_id}:${event.seq}:${event.name}`;
+    if (this.seenEventKeys.has(key)) {
+      return false;
+    }
+    this.seenEventKeys.set(key, event.seq);
+    this.seenEventOrder.push(key);
+    const maxSeen = 4000;
+    while (this.seenEventOrder.length > maxSeen) {
+      const oldest = this.seenEventOrder.shift();
+      if (oldest) {
+        this.seenEventKeys.delete(oldest);
+      }
+    }
+    return true;
+  }
+
+  private recordEventTime(now: number): void {
+    this.eventTimes.push(now);
+    const windowMs = 6000;
+    const minTs = now - windowMs;
+    while (this.eventTimes.length > 0) {
+      const first = this.eventTimes[0];
+      if (first === undefined || first >= minTs) {
+        break;
+      }
+      this.eventTimes.shift();
+    }
+  }
+
+  private updateEventsPerSecond(): void {
+    const now = Date.now();
+    const windowMs = 5000;
+    const minTs = now - windowMs;
+    while (this.eventTimes.length > 0) {
+      const first = this.eventTimes[0];
+      if (first === undefined || first >= minTs) {
+        break;
+      }
+      this.eventTimes.shift();
+    }
+    this.eventsPerSecond = this.eventTimes.length / (windowMs / 1000);
+    this.updateHudText();
+  }
+
+  private createJobFromSeed(seed: JobSeed, now: number): Job {
+    this.jobCounter += 1;
+    const districtId = seed.districtId ?? "region.unknown";
+    return {
+      id: `${seed.id}:${this.jobCounter}`,
+      seed,
+      type: seed.type,
+      stationId: seed.stationId,
+      districtId,
+      buildingId: seed.buildingId,
+      createdAt: now,
+      step: "to_station",
+      stepStartedAt: now
+    };
+  }
+
+  private markHotspotForJob(job: Job): void {
+    const position = this.positionForJob(job);
+    if (!position) {
+      return;
+    }
+    this.hotspot = {
+      position,
+      expiresAt: Date.now() + HOTSPOT_LINGER_MS
+    };
+  }
+
+  private positionForJob(job: Job): Vec2 | null {
+    if (job.buildingId) {
+      const building = this.buildingById.get(job.buildingId);
+      if (building) {
+        return building.position;
+      }
+    }
+    const district = this.districtById.get(job.districtId);
+    if (district) {
+      return district.center;
+    }
+    const station = this.stations.get(job.stationId);
+    return station ? station.position : null;
+  }
+}

--- a/apps/viewer/src/styles.css
+++ b/apps/viewer/src/styles.css
@@ -256,6 +256,18 @@ body {
   border-color: rgba(255, 122, 122, 0.6);
 }
 
+.metric-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.32rem 0.58rem;
+  border-radius: 999px;
+  border: 1px solid rgba(140, 190, 255, 0.26);
+  background: rgba(14, 24, 52, 0.7);
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  letter-spacing: 0.2px;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;
@@ -301,6 +313,21 @@ body {
 .button:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+.chapter-notice {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 10px;
+  border: 1px solid rgba(155, 200, 255, 0.42);
+  background: rgba(14, 30, 72, 0.86);
+  color: var(--accent-strong);
+  font-size: 0.92rem;
+  box-shadow: 0 12px 24px rgba(8, 14, 40, 0.45);
+  backdrop-filter: blur(4px);
+  pointer-events: none;
 }
 
 .muted {

--- a/apps/viewer/src/types.ts
+++ b/apps/viewer/src/types.ts
@@ -19,6 +19,7 @@ export type StreamMessage =
       runId: string;
       viewerUrl: string;
       patchlingsDir: string;
+      events?: TelemetryEventV1[];
     }
   | {
       type: "batch";

--- a/apps/viewer/src/usePatchlingsStream.ts
+++ b/apps/viewer/src/usePatchlingsStream.ts
@@ -62,6 +62,7 @@ function appendRecentEvents(prev: TelemetryEventV1[], events: TelemetryEventV1[]
 
 function reduceMessage(state: ViewerState, message: StreamMessage): ViewerState {
   if (message.type === "snapshot") {
+    const snapshotEvents = message.events ?? [];
     return {
       ...state,
       connected: true,
@@ -71,6 +72,7 @@ function reduceMessage(state: ViewerState, message: StreamMessage): ViewerState 
       patchlingsDir: message.patchlingsDir,
       world: message.world,
       chapters: message.chapters,
+      recentEvents: appendRecentEvents([], snapshotEvents),
       lastDetail: null
     };
   }

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -19,6 +19,9 @@ export default defineConfig({
       },
       "/health": {
         target: RUNNER_TARGET
+      },
+      "/patchlings-assets": {
+        target: RUNNER_TARGET
       }
     }
   },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Patchlings is an engine plus themes. The runner bridges upstream event streams i
 4. Redaction strips sensitive keys and hashes identifiers by salt
 5. Engine reduces events into persistent world state plus chapters
 6. Runner batches and streams updates to the viewer over `/stream`
-7. Themes reduce world state into render state for the UI
+7. Viewer consumes world state plus events and renders the PixiJS Universe simulation
 
 ## Chapter Semantics (Locked)
 
@@ -49,3 +49,12 @@ A theme consumes:
 
 It produces a render state for the viewer. The built-in `Universe` theme focuses on clarity and stability first, then aesthetics.
 
+## Viewer Rendering (v0.1)
+
+The current viewer implements the Universe theme as a PixiJS colony simulation. It connects only to runner endpoints:
+
+- `/stream`
+- `/export/storytime`
+- `/patchlings-assets/*`
+
+By default, sprite assets are served from `patchling_characters/patchlings_branding_images/`.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,29 +2,60 @@
 
 Patchlings is a standalone OSS repo. It does not assume anything about the host project beyond a working directory and an event stream.
 
-## 1) Install
+Node 20+ is recommended.
+
+## 1) Install (Pinned pnpm, No Corepack Required)
+
+This repo pins pnpm via `packageManager`. On Windows, `corepack enable` can fail due to permissions; treat that as non-blocking and continue.
 
 ```bash
-npm install -g pnpm
-pnpm install
+npx pnpm@9.12.0 install
 ```
-
-Node 20+ is recommended.
 
 ## 2) Demo Mode (No Codex Required)
 
 ```bash
-pnpm demo
+npx pnpm@9.12.0 demo
 ```
 
 Open:
 
-- Viewer: `http://localhost:5173`
+- Viewer (Vite dev server): `http://localhost:5173`
 - Runner health: `http://localhost:4317/health`
 
-The viewer dev server proxies `/stream` and `/export/storytime` to the runner.
+The viewer dev server proxies `/stream`, `/export/storytime`, and `/patchlings-assets` to the runner.
 
-## 3) Codex CLI Integration
+If port `4317` is busy:
+
+```bash
+PATCHLINGS_PORT=4321 npx pnpm@9.12.0 demo
+```
+
+PowerShell:
+
+```powershell
+$env:PATCHLINGS_PORT=4321; npx pnpm@9.12.0 demo
+```
+
+## 3) Sprite Assets (Optional, Canonical Path)
+
+By default, the runner serves sprite assets from:
+
+- `patchling_characters/patchlings_branding_images/`
+
+Expected subpaths:
+
+- Sheets: `patchling_characters/patchlings_branding_images/sprites_v1/sheets/`
+- Frames: `patchling_characters/patchlings_branding_images/sprites_v1/sprites/`
+
+If assets are missing, the viewer falls back to simple placeholder Patchlings and logs a clear warning.
+
+Overrides:
+
+- Runner asset root: `PATCHLINGS_ASSETS_DIR`
+- Viewer asset base URL: `VITE_PATCHLINGS_ASSET_BASE` (default `/patchlings-assets`)
+
+## 4) Codex CLI Integration
 
 Patchlings ingests machine-readable JSONL from:
 
@@ -35,23 +66,23 @@ codex exec --json "<prompt>"
 Run it through Patchlings:
 
 ```bash
-pnpm run -- "Implement a demo adapter and render a persistent world."
+npx pnpm@9.12.0 run -- "Implement a demo adapter and render a persistent world."
 ```
 
 Then open `http://localhost:5173`.
 
-## 4) Replay A Recording
+## 5) Replay A Recording
 
 Recordings are stored under `.patchlings/recordings/`.
 
 ```bash
-pnpm replay -- .patchlings/recordings/<run_id>.jsonl
+npx pnpm@9.12.0 replay -- .patchlings/recordings/<run_id>.jsonl
 ```
 
-## 5) Export Story Time
+## 6) Export Story Time
 
 ```bash
-pnpm export-story -- latest
+npx pnpm@9.12.0 export-story -- latest
 ```
 
 Output:
@@ -61,5 +92,6 @@ Output:
 ## Useful Environment Variables
 
 - `PATCHLINGS_PORT`: runner HTTP/WS port (default `4317`)
+- `PATCHLINGS_ASSETS_DIR`: override the canonical asset root
+- `VITE_PATCHLINGS_ASSET_BASE`: override the viewer asset base URL
 - `PATCHLINGS_ALLOW_CONTENT`: opt into raw content display/storage (default `false`)
-

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -6,6 +6,16 @@ The built-in theme is:
 
 - Patchlings: Universe (default)
 
+## Universe Viewer (PixiJS Colony)
+
+In v0.1, the Universe theme is implemented as a PixiJS top-down colony simulation. It still consumes `{ world, events, chapters }` from the runner, but renders through a simulation layer instead of a pure JSON render state.
+
+Asset conventions:
+
+- Canonical asset root: `patchling_characters/patchlings_branding_images/`
+- Runner asset route: `/patchlings-assets`
+- Viewer asset base override: `VITE_PATCHLINGS_ASSET_BASE`
+
 ## Theme Interface
 
 Themes live in `packages/themes` today, but the interface is designed so theme packs can be published independently later.
@@ -51,8 +61,8 @@ export const myTheme: Theme = {
 - Expect identifiers to be hashed
 - Cap entity counts to protect frame time
 - Treat themes as pure reducers
+- Prefer metadata-driven visuals that remain safe under redaction
 
 ## Learn-lings Overlay
 
 Learn-lings is a UI overlay driven by event mappings. It is not baked into a theme and can be toggled independently.
-

--- a/docs/WP-003-pixi-universe-viewer.md
+++ b/docs/WP-003-pixi-universe-viewer.md
@@ -1,0 +1,48 @@
+# WP-003 — PixiJS Universe Viewer + Patchlings Colony Simulation (v0.1)
+
+## Goal
+Upgrade the Universe viewer to a PixiJS top-down colony simulation driven by the existing runner WebSocket stream and TelemetryEventV1 events.
+
+## Scope (In)
+- Add PixiJS to `apps/viewer`.
+- Implement a layered Pixi scene graph with pannable/zoomable camera.
+- Implement Patchling entities with `idle | walk | carry | interact` states.
+- Implement stations + job system driven by normalized telemetry.
+- Implement sprite loading from `patchling_characters/patchlings_branding_images/` with fallback.
+- Wire Learn-lings overlay + timeline + Story Time export to existing runner APIs.
+- Add asset sanity check warnings at startup.
+- Update `docs/QUICKSTART.md` and `docs/THEMES.md`.
+
+## Scope (Out)
+- High-fidelity building art.
+- Deep theme/plugin architecture changes.
+- Any changes to security/privacy defaults.
+
+## Constraints
+- Privacy-first: metadata only, no raw prompts/tool payloads.
+- Viewer talks only to runner (`/stream`, `/export/storytime`, `/patchlings-assets/*`).
+- Keep scope tight and ship a functional colony loop.
+
+## Plan
+1. Add an asset route + sanity checks in the runner.
+2. Add PixiJS to the viewer app.
+3. Implement a Pixi colony simulation:
+   - Scene graph layers
+   - Camera pan/zoom + soft follow hotspot
+   - Stations, districts, buildings, paths
+   - Patchlings, jobs, and basic FX
+4. Wire telemetry to jobs + hotspot + UI cues.
+5. Update docs and validate with `pnpm demo`.
+
+## Acceptance Criteria
+- `pnpm demo` renders a top-down world and Patchlings move around doing jobs.
+- Patchlings visually switch idle/walk/carry states.
+- Chapter timeline updates on `turn.completed`.
+- Learn-lings toggle works and remains metadata-only.
+- Works without any sprite assets (fallback mode), but uses sprites when present.
+- No secrets displayed.
+
+## References
+- Canonical asset root (default): `patchling_characters/patchlings_branding_images/`
+- Sprite sheets: `patchling_characters/patchlings_branding_images/sprites_v1/sheets/`
+- Individual frames: `patchling_characters/patchlings_branding_images/sprites_v1/sprites/`

--- a/docs/checkins/WP-003.md
+++ b/docs/checkins/WP-003.md
@@ -1,0 +1,23 @@
+# WP-003 Check-ins — PixiJS Universe Viewer + Colony Simulation
+
+## Preflight
+- WP issue: #11
+- Branch: `wp/003-pixi-universe-viewer`
+- Commands to validate:
+  - `npx pnpm@9.12.0 install`
+  - `npx pnpm@9.12.0 typecheck`
+  - `npx pnpm@9.12.0 test`
+  - `npx pnpm@9.12.0 demo`
+
+## Milestones
+- [x] Runner asset route + sanity check
+- [x] PixiJS dependency + base renderer
+- [x] Colony simulation + jobs
+- [x] Telemetry wiring + hotspot + cues
+- [x] Docs updated + demo validated
+
+## Notes
+- Keep scope tight; prefer reliable placeholders over ambitious art.
+- `/assets` conflicted with Vite build assets; the runner route is now `/patchlings-assets`.
+- Runner snapshots now include recent events so Learn-lings works even after short demo runs finish.
+- Validation (January 27, 2026): typecheck, test, and build all pass. Demo behavior was verified via Playwright screenshots and a stream probe.

--- a/patchling_characters/patchlings_branding_images/README.md
+++ b/patchling_characters/patchlings_branding_images/README.md
@@ -1,0 +1,83 @@
+# Patchlings Branding + Character Assets (Canonical)
+
+This folder is the canonical source of truth for Patchlings character assets. Codex and contributors should look here first for 2D animation assets used by the PixiJS Universe viewer.
+
+Scope:
+- Patchlings branding images (logos, marks, variants)
+- Patchling character sprites and animation assets
+- Any 2D character assets referenced by the viewer
+
+## Expected Structure
+
+```text
+patchling_characters/
+  patchlings_branding_images/
+    sprites_v1/
+      sprites/   # individual frames
+      sheets/    # sprite sheets
+```
+
+## Sprite Conventions (v1)
+
+### Individual Frames
+
+Frames live under:
+- `sprites_v1/sprites/`
+
+Filename convention:
+- `patchling_<action>_<dir>_<frame>_<size>.png`
+
+Allowed values:
+- actions: `idle` | `walk` | `carry`
+- dirs: `S` | `E` | `N` | `W`
+- sizes: `256` | `128` | `64`
+
+Important loader note:
+- The current viewer probes lowercase direction tokens and two-digit frame numbers.
+- Example the loader expects: `patchling_idle_s_01_128.png`
+
+### Sprite Sheets
+
+Sheets live under:
+- `sprites_v1/sheets/`
+
+Filename convention:
+- `patchling_<action>_sheet_128.png`
+
+Layout convention:
+- rows = `S, E, N, W` (in that order)
+- cols = frame index (left to right)
+
+## How The Viewer Loads Assets
+
+The viewer loads sprites from the runner's asset route (default `/patchlings-assets`), which is served from this canonical folder.
+
+Load order:
+1. Prefer sprite sheets for performance.
+2. Fall back to individual frames.
+3. If neither exists, enter placeholder mode.
+
+When assets are missing, the viewer prints exact expected paths in the browser console.
+
+## DO NOT
+
+- Do not rename `patchling_characters/patchlings_branding_images/`.
+- Do not change naming conventions without updating the loader in `apps/viewer/src/colony/assets.ts`.
+- Do not place raw prompt/tool output or sensitive telemetry here.
+
+## Quick Test
+
+1. Run the demo:
+
+```bash
+npx pnpm@9.12.0 demo
+```
+
+2. Open the viewer (see terminal output for the URL).
+3. In the browser console:
+- You should not see sprite-missing warnings.
+- A success signal (if present) should look like: `Loaded Patchlings sprites v1`.
+
+If you see warnings about missing sheets or frames, check:
+- `patchling_characters/patchlings_branding_images/sprites_v1/sheets/`
+- `patchling_characters/patchlings_branding_images/sprites_v1/sprites/`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@patchlings/themes':
         specifier: workspace:*
         version: link:../../packages/themes
+      pixi.js:
+        specifier: ^7.4.0
+        version: 7.4.3
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -522,6 +525,206 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@pixi/accessibility@7.4.3':
+    resolution: {integrity: sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/events': 7.4.3
+
+  '@pixi/app@7.4.3':
+    resolution: {integrity: sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+
+  '@pixi/assets@7.4.3':
+    resolution: {integrity: sha512-StvjiJBSp/j9hHkGu8AFHNvwYUazXq64WhyhytztyDMRkg/l/cL7EcttY5T0qZNWlIpccdr60LUKrWDOuMpkiw==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/color@7.4.3':
+    resolution: {integrity: sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==}
+
+  '@pixi/colord@2.9.6':
+    resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
+  '@pixi/compressed-textures@7.4.3':
+    resolution: {integrity: sha512-uJ3CC+lNX4HIxs6IxEESO50/0A1KxSVm6CO9UlkXzTsNj9ynmdy5BkJ1dzii7LCdqGcHIXHO01yvKuUbJBBQtw==}
+    peerDependencies:
+      '@pixi/assets': 7.4.3
+      '@pixi/core': 7.4.3
+
+  '@pixi/constants@7.4.3':
+    resolution: {integrity: sha512-QGmwJUNQy/vVEHzL6VGQvnwawLZ1wceZMI8HwJAT4/I2uAzbBeFDdmCS8WsTpSWLZjF/DszDc1D8BFp4pVJ5UQ==}
+
+  '@pixi/core@7.4.3':
+    resolution: {integrity: sha512-5YDs11faWgVVTL8VZtLU05/Fl47vaP5Tnsbf+y/WRR0VSW3KhRRGTBU1J3Gdc2xEWbJhUK07KGP7eSZpvtPVgA==}
+
+  '@pixi/display@7.4.3':
+    resolution: {integrity: sha512-b5m2dAaoNAVdxz1oDaxl3XZ059NEOcNtGkxTOZ4EYCw/jcp9sZXkgSROHRzsGn4k+NugH7+9MP4Id2Z0kkdUhw==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/events@7.4.3':
+    resolution: {integrity: sha512-o3j/5Dxq6WDVS6eHfURB/cf/MP+NcsF/eC5PnbSHjXxJmDE7PoTVwLvxexm5uuvNRpFh/6/Fn0V8Vl4gV8sc8w==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+
+  '@pixi/extensions@7.4.3':
+    resolution: {integrity: sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==}
+
+  '@pixi/extract@7.4.3':
+    resolution: {integrity: sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-alpha@7.4.3':
+    resolution: {integrity: sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-blur@7.4.3':
+    resolution: {integrity: sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-color-matrix@7.4.3':
+    resolution: {integrity: sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-displacement@7.4.3':
+    resolution: {integrity: sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-fxaa@7.4.3':
+    resolution: {integrity: sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-noise@7.4.3':
+    resolution: {integrity: sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/graphics@7.4.3':
+    resolution: {integrity: sha512-wWLivD8/URb8A7X4TqCZGG39C91IE+aOuWY/z9NCz5Z6WvA/VWnsc5fLTlO+ggjGHgKF0cSucCXZfUe1wm0AOQ==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/math@7.4.3':
+    resolution: {integrity: sha512-/uJOVhR2DOZ+zgdI6Bs/CwcXT4bNRKsS+TqX3ekRIxPCwaLra+Qdm7aDxT5cTToDzdxbKL5+rwiLu3Y1egILDw==}
+
+  '@pixi/mesh-extras@7.4.3':
+    resolution: {integrity: sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/mesh': 7.4.3
+
+  '@pixi/mesh@7.4.3':
+    resolution: {integrity: sha512-CikqFPtKvU3Zj986/MSoC8X39CWv5CEpiEW/tYp47p4tgQNDSkNWYnDiNYgb+4VX6pNsBrgX4DALLdTR17SlSA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+
+  '@pixi/mixin-cache-as-bitmap@7.4.3':
+    resolution: {integrity: sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/mixin-get-child-by-name@7.4.3':
+    resolution: {integrity: sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==}
+    peerDependencies:
+      '@pixi/display': 7.4.3
+
+  '@pixi/mixin-get-global-position@7.4.3':
+    resolution: {integrity: sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+
+  '@pixi/particle-container@7.4.3':
+    resolution: {integrity: sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/prepare@7.4.3':
+    resolution: {integrity: sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/graphics': 7.4.3
+      '@pixi/text': 7.4.3
+
+  '@pixi/runner@7.4.3':
+    resolution: {integrity: sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==}
+
+  '@pixi/settings@7.4.3':
+    resolution: {integrity: sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==}
+
+  '@pixi/sprite-animated@7.4.3':
+    resolution: {integrity: sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/sprite-tiling@7.4.3':
+    resolution: {integrity: sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/sprite@7.4.3':
+    resolution: {integrity: sha512-iNBrpOFF9nXDT6m2jcyYy6l/sRzklLDDck1eFHprHZwvNquY2nzRfh+RGBCecxhBcijiLJ3fsZN33fP0LDXkvw==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+
+  '@pixi/spritesheet@7.4.3':
+    resolution: {integrity: sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==}
+    peerDependencies:
+      '@pixi/assets': 7.4.3
+      '@pixi/core': 7.4.3
+
+  '@pixi/text-bitmap@7.4.3':
+    resolution: {integrity: sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==}
+    peerDependencies:
+      '@pixi/assets': 7.4.3
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/mesh': 7.4.3
+      '@pixi/text': 7.4.3
+
+  '@pixi/text-html@7.4.3':
+    resolution: {integrity: sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3
+      '@pixi/sprite': 7.4.3
+      '@pixi/text': 7.4.3
+
+  '@pixi/text@7.4.3':
+    resolution: {integrity: sha512-IAF0iu04rPg3oiL0HZsEZI44fpJxq3UZ4xTmx8l1RyhhSXiElLvvSlSH57vt/BKMQZtCs+AqEit7yn8heK2+nQ==}
+    peerDependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/sprite': 7.4.3
+
+  '@pixi/ticker@7.4.3':
+    resolution: {integrity: sha512-tHsAD0iOUb6QSGGw+c8cyRBvxsq/NlfzIFBZLEHhWZ+Bx4a0MmXup6I/yJDGmyPCYE+ctCcAfY13wKAzdiVFgQ==}
+
+  '@pixi/utils@7.4.3':
+    resolution: {integrity: sha512-NO3Y9HAn2UKS1YdxffqsPp+kDpVm8XWvkZcS/E+rBzY9VTLnNOI7cawSRm+dacdET3a8Jad3aDKEDZ0HmAqAFA==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -662,6 +865,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/css-font-loading-module@0.0.12':
+    resolution: {integrity: sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==}
+
+  '@types/earcut@2.1.4':
+    resolution: {integrity: sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -734,6 +943,14 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
@@ -764,11 +981,30 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+
   electron-to-chromium@1.5.279:
     resolution: {integrity: sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -787,6 +1023,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -796,12 +1035,38 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  ismobilejs@1.1.1:
+    resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -829,6 +1094,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -840,6 +1109,10 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
 
@@ -850,9 +1123,19 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  pixi.js@7.4.3:
+    resolution: {integrity: sha512-uIWdH0EI2dVgNoqN9aFaHCmR0V65OEhMkXs2sek3c/QP2ItV6UoM+ouX9esSv3ibo20F+J5D1XwnQhUZI6wqeQ==}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
+
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+    engines: {node: '>=0.6'}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -881,6 +1164,22 @@ packages:
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -931,6 +1230,10 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
 
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
@@ -1293,6 +1596,196 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@pixi/accessibility@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/events': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/app@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/assets@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@types/css-font-loading-module': 0.0.12
+
+  '@pixi/color@7.4.3':
+    dependencies:
+      '@pixi/colord': 2.9.6
+
+  '@pixi/colord@2.9.6': {}
+
+  '@pixi/compressed-textures@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/core': 7.4.3
+
+  '@pixi/constants@7.4.3': {}
+
+  '@pixi/core@7.4.3':
+    dependencies:
+      '@pixi/color': 7.4.3
+      '@pixi/constants': 7.4.3
+      '@pixi/extensions': 7.4.3
+      '@pixi/math': 7.4.3
+      '@pixi/runner': 7.4.3
+      '@pixi/settings': 7.4.3
+      '@pixi/ticker': 7.4.3
+      '@pixi/utils': 7.4.3
+
+  '@pixi/display@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/extensions@7.4.3': {}
+
+  '@pixi/extract@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-alpha@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-blur@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-color-matrix@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-displacement@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-fxaa@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/filter-noise@7.4.3(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/core': 7.4.3
+
+  '@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/math@7.4.3': {}
+
+  '@pixi/mesh-extras@7.4.3(@pixi/core@7.4.3)(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/mixin-cache-as-bitmap@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/mixin-get-child-by-name@7.4.3(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/mixin-get-global-position@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/particle-container@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/prepare@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/graphics': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+
+  '@pixi/runner@7.4.3': {}
+
+  '@pixi/settings@7.4.3':
+    dependencies:
+      '@pixi/constants': 7.4.3
+      '@types/css-font-loading-module': 0.0.12
+      ismobilejs: 1.1.1
+
+  '@pixi/sprite-animated@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/sprite-tiling@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+
+  '@pixi/spritesheet@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)':
+    dependencies:
+      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/core': 7.4.3
+
+  '@pixi/text-bitmap@7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
+    dependencies:
+      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+
+  '@pixi/text-html@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+
+  '@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))':
+    dependencies:
+      '@pixi/core': 7.4.3
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+
+  '@pixi/ticker@7.4.3':
+    dependencies:
+      '@pixi/extensions': 7.4.3
+      '@pixi/settings': 7.4.3
+      '@pixi/utils': 7.4.3
+
+  '@pixi/utils@7.4.3':
+    dependencies:
+      '@pixi/color': 7.4.3
+      '@pixi/constants': 7.4.3
+      '@pixi/settings': 7.4.3
+      '@types/earcut': 2.1.4
+      earcut: 2.2.4
+      eventemitter3: 4.0.7
+      url: 0.11.4
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.57.0':
@@ -1391,6 +1884,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.6
 
+  '@types/css-font-loading-module@0.0.12': {}
+
+  '@types/earcut@2.1.4': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/node@22.19.7':
@@ -1478,6 +1975,16 @@ snapshots:
 
   cac@6.7.14: {}
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001766: {}
 
   chai@5.3.3:
@@ -1500,9 +2007,25 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  earcut@2.2.4: {}
+
   electron-to-chromium@1.5.279: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1565,16 +2088,48 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventemitter3@4.0.7: {}
+
   expect-type@1.3.0: {}
 
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   gensync@1.0.0-beta.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  ismobilejs@1.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -1596,11 +2151,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   node-releases@2.0.27: {}
+
+  object-inspect@1.13.4: {}
 
   pathe@1.1.2: {}
 
@@ -1608,11 +2167,50 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  pixi.js@7.4.3:
+    dependencies:
+      '@pixi/accessibility': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/events@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/app': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/assets': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/compressed-textures': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)
+      '@pixi/core': 7.4.3
+      '@pixi/display': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/events': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/extensions': 7.4.3
+      '@pixi/extract': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-alpha': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-blur': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-color-matrix': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-displacement': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-fxaa': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/filter-noise': 7.4.3(@pixi/core@7.4.3)
+      '@pixi/graphics': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/mesh': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/mesh-extras': 7.4.3(@pixi/core@7.4.3)(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/mixin-cache-as-bitmap': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/mixin-get-child-by-name': 7.4.3(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/mixin-get-global-position': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/particle-container': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/prepare': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/graphics@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
+      '@pixi/sprite': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))
+      '@pixi/sprite-animated': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/sprite-tiling': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/spritesheet': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)
+      '@pixi/text': 7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))
+      '@pixi/text-bitmap': 7.4.3(@pixi/assets@7.4.3(@pixi/core@7.4.3))(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/mesh@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
+      '@pixi/text-html': 7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3)))(@pixi/text@7.4.3(@pixi/core@7.4.3)(@pixi/sprite@7.4.3(@pixi/core@7.4.3)(@pixi/display@7.4.3(@pixi/core@7.4.3))))
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  punycode@1.4.1: {}
+
+  qs@6.14.1:
+    dependencies:
+      side-channel: 1.1.0
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -1665,6 +2263,34 @@ snapshots:
 
   semver@6.3.1: {}
 
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1699,6 +2325,11 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.14.1
 
   vite-node@2.1.9(@types/node@22.19.7):
     dependencies:


### PR DESCRIPTION
## Summary

This PR upgrades the Universe viewer to a PixiJS top-down colony simulation driven by runner telemetry. It also fixes a Learn-lings gap by buffering recent events in runner snapshots.

Fixes #11.

## How To Run

Install:

```bash
npx pnpm@9.12.0 install
```

Demo:

```bash
npx pnpm@9.12.0 demo
```

If port 4317 is busy:

```bash
PATCHLINGS_PORT=4321 npx pnpm@9.12.0 demo
```

Run with Codex:

```bash
npx pnpm@9.12.0 run -- "Your prompt here"
```

## Sprite Assets (Canonical Path)

Place assets under:

- `patchling_characters/patchlings_branding_images/`

Expected subpaths:

- `patchling_characters/patchlings_branding_images/sprites_v1/sheets/`
- `patchling_characters/patchlings_branding_images/sprites_v1/sprites/`

Defaults:

- Runner serves assets at `/patchlings-assets`
- Viewer uses `/patchlings-assets` unless `VITE_PATCHLINGS_ASSET_BASE` is set

## What Changed (High Level)

- PixiJS colony simulation with layered scene graph, stations, jobs, and Patchling state machine
- Canonical asset route (`/patchlings-assets`) with sanity checks and clear fallback warnings
- Snapshot now includes recent events so Learn-lings works even after short demo runs
- Docs updated for pinned pnpm, Pixi viewer, and asset conventions

## Validation

- `npx pnpm@9.12.0 typecheck`
- `npx pnpm@9.12.0 test`
- `npx pnpm@9.12.0 build`
- `npx pnpm@9.12.0 demo` (plus stream probe)

## Intentionally Left For Later

- Higher-fidelity building art and richer district mapping
- More expressive Patchling behaviors, UI, and FX

## Monitoring Status

- Stream: runner `/stream` confirmed
- Learn-lings: snapshot events -> explanations confirmed
- Assets: missing assets fall back cleanly with warnings

## Checklist

- [x] I ran `pnpm test`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm build`
- [x] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes

- No raw prompt/tool payloads are displayed or stored by default
- Recent events in snapshots are already normalized + redacted
