### PR TITLE
WP-004: Canonical assets + asset doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Place Patchling sprites under:
 
 - `patchling_characters/patchlings_branding_images/`
 
-The runner serves them at `/patchlings-assets` by default. Override with `PATCHLINGS_ASSETS_DIR` (runner) or `VITE_PATCHLINGS_ASSET_BASE` (viewer). If assets are missing, the viewer falls back to placeholder Patchlings.
+The runner serves them at `/patchlings-assets` by default. Override with `PATCHLINGS_ASSET_ROOT` (runner) or `VITE_PATCHLINGS_ASSET_BASE` (viewer). If assets are missing, the viewer falls back to placeholder Patchlings.
 
 ## Replay A Recording
 

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -23,6 +23,7 @@
     "run": "tsx src/cli.ts run",
     "replay": "tsx src/cli.ts replay",
     "export-story": "tsx src/cli.ts export-story",
+    "assets": "tsx src/cli.ts assets",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/apps/viewer/src/UniverseCanvas.tsx
+++ b/apps/viewer/src/UniverseCanvas.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 import type { ChapterSummary, WorldState } from "@patchlings/engine";
 import type { TelemetryEventV1 } from "@patchlings/protocol";
 
-import type { RunStatus } from "./types";
+import type { RunStatus, SpriteStatus } from "./types";
 import { ColonySimulation } from "./colony/simulation";
 
 interface UniverseCanvasProps {
@@ -16,6 +16,7 @@ interface UniverseCanvasProps {
   followHotspot: boolean;
   assetBase: string;
   onChapterSaved?: (runId: string) => void;
+  onSpriteStatus?: (status: SpriteStatus) => void;
 }
 
 export function UniverseCanvas(props: UniverseCanvasProps): JSX.Element {
@@ -27,11 +28,12 @@ export function UniverseCanvas(props: UniverseCanvasProps): JSX.Element {
     if (!host) {
       return;
     }
-    const options = props.onChapterSaved
+    const options = props.onChapterSaved || props.onSpriteStatus
       ? {
           assetBase: props.assetBase,
           followHotspot: props.followHotspot,
-          onChapterSaved: props.onChapterSaved
+          ...(props.onChapterSaved ? { onChapterSaved: props.onChapterSaved } : {}),
+          ...(props.onSpriteStatus ? { onSpriteStatus: props.onSpriteStatus } : {})
         }
       : {
           assetBase: props.assetBase,

--- a/apps/viewer/src/colony/simulation.ts
+++ b/apps/viewer/src/colony/simulation.ts
@@ -5,6 +5,7 @@ import type { TelemetryEventV1 } from "@patchlings/protocol";
 
 import { loadPatchlingSprites, type PatchlingAction, type PatchlingDir, type PatchlingSpriteSet } from "./assets";
 import { mapEventToJobSeed, type JobSeed, type JobType, type StationId } from "./jobs";
+import type { SpriteStatus } from "../types";
 
 export type RunStatus = "idle" | "running" | "completed" | "failed";
 
@@ -12,6 +13,7 @@ export interface ColonySimulationOptions {
   assetBase: string;
   followHotspot: boolean;
   onChapterSaved?: (runId: string) => void;
+  onSpriteStatus?: (status: SpriteStatus) => void;
 }
 
 interface Layers {
@@ -243,6 +245,8 @@ export class ColonySimulation {
 
   private onChapterSaved?: (runId: string) => void;
 
+  private onSpriteStatus?: (status: SpriteStatus) => void;
+
   private runStatus: RunStatus = "idle";
 
   private runId = "pending";
@@ -321,6 +325,9 @@ export class ColonySimulation {
     if (options.onChapterSaved) {
       this.onChapterSaved = options.onChapterSaved;
     }
+    if (options.onSpriteStatus) {
+      this.onSpriteStatus = options.onSpriteStatus;
+    }
 
     this.camera = {
       x: INITIAL_CAMERA.x,
@@ -391,6 +398,12 @@ export class ColonySimulation {
   async setAssetBase(assetBase: string): Promise<void> {
     this.sprites = await loadPatchlingSprites({ assetBase });
     this.refreshAgentSprites();
+    if (this.sprites) {
+      this.onSpriteStatus?.({
+        mode: this.sprites.mode,
+        assetBase: this.sprites.assetBase
+      });
+    }
   }
 
   ingestWorld(world: WorldState | null): void {

--- a/apps/viewer/src/styles.css
+++ b/apps/viewer/src/styles.css
@@ -268,6 +268,16 @@ body {
   letter-spacing: 0.2px;
 }
 
+.metric-pill--ok {
+  border-color: rgba(86, 203, 138, 0.6);
+  color: #b5f5d1;
+}
+
+.metric-pill--warn {
+  border-color: rgba(255, 176, 86, 0.6);
+  color: #ffe2b0;
+}
+
 .status-dot {
   width: 8px;
   height: 8px;

--- a/apps/viewer/src/types.ts
+++ b/apps/viewer/src/types.ts
@@ -10,6 +10,13 @@ export interface StreamStats {
   queueSize: number;
 }
 
+export type SpriteMode = "sprites" | "placeholder";
+
+export interface SpriteStatus {
+  mode: SpriteMode;
+  assetBase: string;
+}
+
 export type StreamMessage =
   | {
       type: "snapshot";

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,4 +57,9 @@ The current viewer implements the Universe theme as a PixiJS colony simulation. 
 - `/export/storytime`
 - `/patchlings-assets/*`
 
-By default, sprite assets are served from `patchling_characters/patchlings_branding_images/`.
+By default, sprite assets are served from `patchling_characters/patchlings_branding_images/` (the canonical asset root).
+
+The loader order is:
+1. Sprite sheets (preferred for performance)
+2. Individual frames
+3. Placeholder mode (with explicit console warnings)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -52,8 +52,22 @@ If assets are missing, the viewer falls back to simple placeholder Patchlings an
 
 Overrides:
 
-- Runner asset root: `PATCHLINGS_ASSETS_DIR`
+- Runner asset root: `PATCHLINGS_ASSET_ROOT`
 - Viewer asset base URL: `VITE_PATCHLINGS_ASSET_BASE` (default `/patchlings-assets`)
+
+### Asset Doctor
+
+Run a quick sanity check:
+
+```bash
+npx pnpm@9.12.0 --filter @patchlings/runner assets doctor
+```
+
+If the `patchlings` CLI is installed:
+
+```bash
+patchlings assets doctor
+```
 
 ## 4) Codex CLI Integration
 
@@ -92,6 +106,6 @@ Output:
 ## Useful Environment Variables
 
 - `PATCHLINGS_PORT`: runner HTTP/WS port (default `4317`)
-- `PATCHLINGS_ASSETS_DIR`: override the canonical asset root
+- `PATCHLINGS_ASSET_ROOT`: override the canonical asset root
 - `VITE_PATCHLINGS_ASSET_BASE`: override the viewer asset base URL
 - `PATCHLINGS_ALLOW_CONTENT`: opt into raw content display/storage (default `false`)

--- a/docs/WP-004-asset-doctor.md
+++ b/docs/WP-004-asset-doctor.md
@@ -1,0 +1,33 @@
+# WP-004 — Canonical Assets + Asset Doctor
+
+## Goal
+Lock in Patchlings character asset conventions and add a robust asset doctor + viewer UX so contributors never get confused.
+
+## Scope (In)
+- Canonical asset README + gitkeep structure
+- Single source of truth for asset root constant
+- Asset doctor command with exit codes
+- Viewer startup logging + HUD pill for sprite status
+- Docs updates (Quickstart + Architecture)
+
+## Scope (Out)
+- New art assets
+- Theme/engine features unrelated to asset loading
+
+## Constraints
+- Privacy-first: no secrets or prompt/tool payloads in output
+- Canonical asset root is `patchling_characters/patchlings_branding_images/`
+- Keep defaults backward compatible where possible
+
+## Plan
+1. Add canonical constant and env override handling.
+2. Implement asset doctor command.
+3. Update viewer startup logs + HUD pill.
+4. Update docs and validate.
+
+## Acceptance Criteria
+- README documents asset conventions and folder layout.
+- Asset doctor reports status and exits 0/1 correctly.
+- Viewer logs "Loaded Patchlings sprites v1" or "Patchlings sprites missing; running placeholder mode".
+- HUD shows "Sprites: Loaded" or "Sprites: Placeholder".
+- Docs mention canonical root + fallback order + doctor command.

--- a/docs/checkins/WP-004.md
+++ b/docs/checkins/WP-004.md
@@ -1,0 +1,19 @@
+# WP-004 Check-ins — Canonical Assets + Asset Doctor
+
+## Preflight
+- WP issue: #13
+- Branch: `wp/004-asset-doctor`
+- Commands to validate:
+  - `npx pnpm@9.12.0 typecheck`
+  - `npx pnpm@9.12.0 test`
+
+## Milestones
+- [x] Canonical asset constant + env override
+- [x] Asset doctor command
+- [x] Viewer sprite status logging + HUD pill
+- [x] Docs updated + validation
+
+## Notes
+- Keep outputs metadata-only.
+- Validation (January 27, 2026): `npx pnpm@9.12.0 test` + `npx pnpm@9.12.0 typecheck`.
+- Asset doctor run against canonical root returned placeholder mode (expected without sprites_v1 assets).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "run": "pnpm --filter @patchlings/runner run --",
     "replay": "pnpm --filter @patchlings/runner replay --",
     "export-story": "pnpm --filter @patchlings/runner export-story --",
+    "assets": "pnpm --filter @patchlings/runner assets --",
     "build": "pnpm -r build",
     "test": "pnpm -r build && pnpm -r test",
     "typecheck": "pnpm -r typecheck",

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,5 @@
 export const TELEMETRY_VERSION = 1 as const;
+export const DEFAULT_PATCHLINGS_ASSET_ROOT = "patchling_characters/patchlings_branding_images";
 
 export type TelemetryKind =
   | "turn"

--- a/patchling_characters/patchlings_branding_images/README.md
+++ b/patchling_characters/patchlings_branding_images/README.md
@@ -1,6 +1,6 @@
 # Patchlings Branding + Character Assets (Canonical)
 
-This folder is the canonical source of truth for Patchlings character assets. Codex and contributors should look here first for 2D animation assets used by the PixiJS Universe viewer.
+Codex looks here for ALL Patchlings 2D animation + character assets used by the PixiJS Universe viewer.
 
 Scope:
 - Patchlings branding images (logos, marks, variants)
@@ -32,17 +32,13 @@ Allowed values:
 - dirs: `S` | `E` | `N` | `W`
 - sizes: `256` | `128` | `64`
 
-Important loader note:
-- The current viewer probes lowercase direction tokens and two-digit frame numbers.
-- Example the loader expects: `patchling_idle_s_01_128.png`
-
 ### Sprite Sheets
 
 Sheets live under:
 - `sprites_v1/sheets/`
 
 Filename convention:
-- `patchling_<action>_sheet_128.png`
+- `patchling_<action>_sheet_128.png` (and `_64` optional)
 
 Layout convention:
 - rows = `S, E, N, W` (in that order)
@@ -62,7 +58,7 @@ When assets are missing, the viewer prints exact expected paths in the browser c
 ## DO NOT
 
 - Do not rename `patchling_characters/patchlings_branding_images/`.
-- Do not change naming conventions without updating the loader in `apps/viewer/src/colony/assets.ts`.
+- Do not change naming conventions without updating the loader in `apps/viewer/src/colony/assets.ts` and this README.
 - Do not place raw prompt/tool output or sensitive telemetry here.
 
 ## Quick Test
@@ -75,8 +71,9 @@ npx pnpm@9.12.0 demo
 
 2. Open the viewer (see terminal output for the URL).
 3. In the browser console:
-- You should not see sprite-missing warnings.
-- A success signal (if present) should look like: `Loaded Patchlings sprites v1`.
+- You should see one of the following logs:
+  - `Loaded Patchlings sprites v1 from <path>`
+  - `Placeholder mode: missing sprites`
 
 If you see warnings about missing sheets or frames, check:
 - `patchling_characters/patchlings_branding_images/sprites_v1/sheets/`


### PR DESCRIPTION
## Summary

This PR locks the canonical Patchlings asset conventions, adds an asset doctor command, and improves viewer sprite status UX.

Fixes #13.

## Stacked PR

This branch is stacked on top of `wp/003-pixi-universe-viewer` because it modifies the PixiJS viewer and assets loader introduced there.

## How To Run

```bash
npx pnpm@9.12.0 install
npx pnpm@9.12.0 test
npx pnpm@9.12.0 typecheck
```

Asset doctor:

```bash
npx pnpm@9.12.0 --filter @patchlings/runner assets doctor
```

## What Changed

- Canonical asset root constant (`patchling_characters/patchlings_branding_images/`)
- Asset doctor command with exit codes and missing-path reporting
- Viewer startup logs for sprite status and a HUD pill (`Sprites: Loaded` / `Sprites: Placeholder`)
- Docs updated (Quickstart + Architecture + asset README)

## Validation

- `npx pnpm@9.12.0 test`
- `npx pnpm@9.12.0 typecheck`
- `npx pnpm@9.12.0 --filter @patchlings/runner assets doctor`

## Checklist

- [x] I ran `pnpm test`
- [x] I ran `pnpm typecheck`
- [x] I ran `pnpm build` (via `pnpm test`)
- [x] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes

- Asset doctor and logs emit only local file paths; no secrets or prompt/tool content.
