### PR TITLE
WP-006: Protocol v1 breaking-change callout

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,13 @@ Patchlings is an engine plus themes. The runner bridges upstream event streams i
 6. Runner batches and streams updates to the viewer over `/stream`
 7. Viewer consumes world state plus events and renders the PixiJS Universe simulation
 
+## Telemetry v1 Contract (Stability)
+
+Telemetry v1 is a public contract. Breaking changes must:
+
+- Bump the protocol version (`v`) and update the schema and TypeScript types.
+- Include a migration note in docs and release notes so downstream consumers can adapt.
+
 ## Chapter Semantics (Locked)
 
 - A chapter opens on `turn.started`

--- a/docs/WP-006-protocol-docs.md
+++ b/docs/WP-006-protocol-docs.md
@@ -1,0 +1,22 @@
+# WP-006 — Protocol v1 Breaking-Change Callout
+
+## Goal
+Document the rule that breaking changes to Telemetry v1 must bump the version and include a migration note.
+
+## Scope (In)
+- Documentation updates (protocol + architecture) clarifying versioning/migrations.
+
+## Scope (Out)
+- Schema or runtime changes.
+
+## Constraints
+- Keep the telemetry contract stable.
+- No behavior changes.
+
+## Plan
+1. Add explicit breaking-change/version bump callout in docs.
+2. Validate documentation accuracy.
+
+## Acceptance Criteria
+- Docs clearly state: breaking changes require a version bump and migration note.
+- No runtime behavior changes.

--- a/docs/checkins/WP-006.md
+++ b/docs/checkins/WP-006.md
@@ -7,7 +7,7 @@
   - (doc-only change)
 
 ## Milestones
-- [ ] Add breaking-change version bump callout
+- [x] Add breaking-change version bump callout
 - [x] Open draft PR
 
 ## Notes

--- a/docs/checkins/WP-006.md
+++ b/docs/checkins/WP-006.md
@@ -1,0 +1,14 @@
+# WP-006 Check-ins — Protocol v1 Breaking-Change Callout
+
+## Preflight
+- WP issue: #18
+- Branch: `wp/006-protocol-docs`
+- Commands to validate:
+  - (doc-only change)
+
+## Milestones
+- [ ] Add breaking-change version bump callout
+- [ ] Open draft PR
+
+## Notes
+- Observability not run (doc-only change; codex CLI not available).

--- a/docs/checkins/WP-006.md
+++ b/docs/checkins/WP-006.md
@@ -8,7 +8,7 @@
 
 ## Milestones
 - [ ] Add breaking-change version bump callout
-- [ ] Open draft PR
+- [x] Open draft PR
 
 ## Notes
 - Observability not run (doc-only change; codex CLI not available).


### PR DESCRIPTION
## Summary
- WP-006 scaffolding: add protocol versioning callout plan and check-in.

## Checklist
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [x] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes
Doc-only change.

## Monitoring Status
- Telemetry: not run (doc-only change; codex CLI not available)
- Viewer: not run
- Risk: docs only

Fixes #18
