### PR TITLE
WP-007: Codex JSONL mapping fixtures + tests

### DIFF
--- a/docs/WP-007-codex-mapping-tests.md
+++ b/docs/WP-007-codex-mapping-tests.md
@@ -1,0 +1,25 @@
+# WP-007 — Codex JSONL Mapping Fixtures + Tests
+
+## Goal
+Add fixtures and tests that validate Codex JSONL mapping behavior.
+
+## Scope (In)
+- Fixture JSONL events covering thread/turn/item/error cases.
+- Adapter tests that verify mapping + redaction behavior.
+
+## Scope (Out)
+- Runtime behavior changes beyond test visibility.
+
+## Constraints
+- No raw prompt/tool payloads in fixtures.
+- Keep tests deterministic.
+
+## Plan
+1. Add fixture JSONL file(s) under packages/adapters/test/fixtures.
+2. Add mapping tests and expose minimal helpers if needed.
+3. Run adapter tests.
+
+## Acceptance Criteria
+- Mapping tests cover item.* -> Telemetry v1 kinds/names.
+- Tests validate seq synthesis and redaction-safe attrs.
+- Fixtures are checked in.

--- a/docs/checkins/WP-007.md
+++ b/docs/checkins/WP-007.md
@@ -1,0 +1,15 @@
+# WP-007 Check-ins — Codex JSONL Mapping Fixtures + Tests
+
+## Preflight
+- WP issue: #19
+- Branch: `wp/007-codex-mapping-tests`
+- Commands to validate:
+  - `npx pnpm@9.12.0 --filter @patchlings/adapters test`
+
+## Milestones
+- [ ] Add mapping fixtures
+- [ ] Add adapter tests
+- [ ] Open draft PR
+
+## Notes
+- Observability not run (local codex CLI not available).

--- a/docs/checkins/WP-007.md
+++ b/docs/checkins/WP-007.md
@@ -9,7 +9,7 @@
 ## Milestones
 - [ ] Add mapping fixtures
 - [ ] Add adapter tests
-- [ ] Open draft PR
+- [x] Open draft PR
 
 ## Notes
 - Observability not run (local codex CLI not available).

--- a/docs/checkins/WP-007.md
+++ b/docs/checkins/WP-007.md
@@ -13,3 +13,4 @@
 
 ## Notes
 - Observability not run (local codex CLI not available).
+- Validation: `npx pnpm@9.12.0 --filter @patchlings/adapters test`.

--- a/docs/checkins/WP-007.md
+++ b/docs/checkins/WP-007.md
@@ -7,8 +7,8 @@
   - `npx pnpm@9.12.0 --filter @patchlings/adapters test`
 
 ## Milestones
-- [ ] Add mapping fixtures
-- [ ] Add adapter tests
+- [x] Add mapping fixtures
+- [x] Add adapter tests
 - [x] Open draft PR
 
 ## Notes

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -946,3 +946,13 @@ export async function demoAdapter(options: DemoAdapterOptions): Promise<AdapterH
 
   return { stream: queue, stop };
 }
+
+// Expose minimal helpers for adapter unit tests without changing runtime behavior.
+export const __test__ = {
+  mapCodexRawEvent,
+  mapCodexItemEvent,
+  normalizeInputEvent,
+  coerceRunIdFromRaw,
+  deriveKind,
+  SeqSynthesizer
+};

--- a/packages/adapters/test/codex-mapping.test.ts
+++ b/packages/adapters/test/codex-mapping.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { hashPath, hashWithSalt } from "@patchlings/redact";
+import { __test__ } from "../src/index.js";
+
+const FIXTURE_PATH = new URL("./fixtures/codex.jsonl", import.meta.url);
+
+function loadFixtureLines(): string[] {
+  const text = readFileSync(FIXTURE_PATH, "utf8").trim();
+  return text.length === 0 ? [] : text.split(/\r?\n/);
+}
+
+describe("codex JSONL mapping", () => {
+  it("maps fixture events into Telemetry v1 safely", () => {
+    const lines = loadFixtureLines();
+    const context = {
+      runId: "fallback-run",
+      workspaceSalt: "workspace-salt",
+      runSalt: "run-salt",
+      getRunSalt: () => "run-salt"
+    };
+    const prompt = "sample prompt";
+    const seqSynth = new __test__.SeqSynthesizer();
+
+    const events = lines
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .map((raw) => {
+        const mapped = __test__.mapCodexRawEvent(raw, prompt, context);
+        return __test__.normalizeInputEvent(mapped, context, seqSynth);
+      })
+      .filter((event): event is NonNullable<typeof event> => Boolean(event));
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.map((event) => event.seq)).toEqual([0, 1, 2, 3, 4, 5]);
+
+    const threadStart = events.find((event) => event.name === "thread.started");
+    expect(threadStart?.kind).toBe("spawn");
+    expect(threadStart?.run_id).toBe("thread-1");
+
+    const turnStart = events.find((event) => event.name === "turn.started");
+    expect(turnStart?.kind).toBe("turn");
+    expect(turnStart?.attrs?.prompt_hash).toBe(hashWithSalt(prompt, "run-salt"));
+
+    const fileEvent = events.find((event) => event.kind === "file");
+    expect(fileEvent?.name).toBe("file.write");
+    expect(fileEvent?.attrs?.path).toBeUndefined();
+    expect(fileEvent?.attrs?.path_hash).toBe(hashPath("src/index.ts", "run-salt"));
+    expect(fileEvent?.attrs?.path_stable_hash).toBe(hashPath("src/index.ts", "workspace-salt"));
+
+    const toolEvent = events.find((event) => event.name === "tool.shell.start");
+    expect(toolEvent?.kind).toBe("tool");
+
+    const testEvent = events.find((event) => event.kind === "test");
+    expect(testEvent?.name).toBe("test.pass");
+
+    const errorEvent = events.find((event) => event.kind === "error");
+    expect(errorEvent?.severity).toBe("error");
+    expect(errorEvent?.attrs?.error_code).toBe(hashWithSalt("boom", "run-salt"));
+  });
+});

--- a/packages/adapters/test/fixtures/codex.jsonl
+++ b/packages/adapters/test/fixtures/codex.jsonl
@@ -1,0 +1,6 @@
+{"type":"thread.started","thread_id":"thread-1","ts":"2026-01-01T00:00:00.000Z"}
+{"type":"turn.started","thread_id":"thread-1","turn_id":"turn-1","ts":"2026-01-01T00:00:01.000Z","seq":1}
+{"type":"item.patch","thread_id":"thread-1","item":{"id":"item-1","type":"file","path":"src/index.ts"},"ts":"2026-01-01T00:00:02.000Z","seq":2}
+{"type":"item.tool.started","thread_id":"thread-1","item":{"id":"item-2","tool_name":"shell"},"ts":"2026-01-01T00:00:03.000Z","seq":3}
+{"type":"item.test","thread_id":"thread-1","item":{"id":"item-3","kind":"test","result":"pass"},"ts":"2026-01-01T00:00:04.000Z","seq":4}
+{"type":"error","thread_id":"thread-1","error":{"message":"boom"},"ts":"2026-01-01T00:00:05.000Z","seq":5}


### PR DESCRIPTION
## Summary
- WP-007 scaffolding: add codex mapping test plan and check-in.

## Checklist
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [ ] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes
Test-only change; fixtures are metadata-only.

## Monitoring Status
- Telemetry: not run (local codex CLI not available)
- Viewer: not run
- Risk: tests + fixtures only

Fixes #19
