### PR TITLE
WP-008: Themes plan callout

### DIFF
--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -63,6 +63,14 @@ export const myTheme: Theme = {
 - Treat themes as pure reducers
 - Prefer metadata-driven visuals that remain safe under redaction
 
+## Example Theme Pack Plan (Upcoming)
+
+We plan to publish a small, standalone example theme pack to demonstrate the theme API in practice. The initial pack will:
+
+- Export a single theme with a minimal reducer and a tiny asset bundle.
+- Document setup steps (install, register, run) without requiring any code changes in Patchlings.
+- Serve as a reference for performance caps and privacy-safe rendering.
+
 ## Learn-lings Overlay
 
 Learn-lings is a UI overlay driven by event mappings. It is not baked into a theme and can be toggled independently.

--- a/docs/WP-008-themes-plan-callout.md
+++ b/docs/WP-008-themes-plan-callout.md
@@ -1,0 +1,22 @@
+# WP-008 — Themes Plan Callout
+
+## Goal
+Add an explicit example theme-pack plan callout in docs.
+
+## Scope (In)
+- docs/THEMES.md updates only.
+
+## Scope (Out)
+- Theme API code changes.
+
+## Constraints
+- Keep content privacy-first.
+- No runtime behavior changes.
+
+## Plan
+1. Add a theme-pack plan callout section.
+2. Validate docs for clarity.
+
+## Acceptance Criteria
+- Docs include a clear plan for a future example theme pack.
+- No runtime behavior changes.

--- a/docs/checkins/WP-008.md
+++ b/docs/checkins/WP-008.md
@@ -7,7 +7,7 @@
   - (doc-only change)
 
 ## Milestones
-- [ ] Add theme-pack plan callout
+- [x] Add theme-pack plan callout
 - [x] Open draft PR
 
 ## Notes

--- a/docs/checkins/WP-008.md
+++ b/docs/checkins/WP-008.md
@@ -8,7 +8,7 @@
 
 ## Milestones
 - [ ] Add theme-pack plan callout
-- [ ] Open draft PR
+- [x] Open draft PR
 
 ## Notes
 - Observability not run (doc-only change; codex CLI not available).

--- a/docs/checkins/WP-008.md
+++ b/docs/checkins/WP-008.md
@@ -1,0 +1,14 @@
+# WP-008 Check-ins — Themes Plan Callout
+
+## Preflight
+- WP issue: #20
+- Branch: `wp/008-themes-plan-callout`
+- Commands to validate:
+  - (doc-only change)
+
+## Milestones
+- [ ] Add theme-pack plan callout
+- [ ] Open draft PR
+
+## Notes
+- Observability not run (doc-only change; codex CLI not available).


### PR DESCRIPTION
## Summary
- WP-008 scaffolding: add themes plan callout plan and check-in.

## Checklist
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [x] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes
Doc-only change.

## Monitoring Status
- Telemetry: not run (doc-only change; codex CLI not available)
- Viewer: not run
- Risk: docs only

Fixes #20
