### PR TITLE
WP-009: Replay fixture + truncated line coverage

### DIFF
--- a/docs/WP-009-replay-fixture.md
+++ b/docs/WP-009-replay-fixture.md
@@ -1,0 +1,25 @@
+# WP-009 — Replay Fixture + Truncated Line Coverage
+
+## Goal
+Add deterministic replay fixtures and coverage for truncated lines in replay adapters.
+
+## Scope (In)
+- Fixture JSONL recording(s).
+- Tests for truncated line handling and determinism with fixture.
+
+## Scope (Out)
+- Replay UX changes.
+
+## Constraints
+- Fixtures must be metadata-only.
+- Tests must be deterministic.
+
+## Plan
+1. Add recording fixture under test fixtures.
+2. Add tests for file-tail adapter truncated line handling.
+3. Add determinism test that replays fixture.
+
+## Acceptance Criteria
+- Fixture file checked in.
+- Tests cover truncated line handling and deterministic replay.
+- Docs remain unchanged unless needed.

--- a/docs/checkins/WP-009.md
+++ b/docs/checkins/WP-009.md
@@ -8,8 +8,8 @@
   - `npx pnpm@9.12.0 --filter @patchlings/engine test`
 
 ## Milestones
-- [ ] Add replay fixture
-- [ ] Add truncated line coverage tests
+- [x] Add replay fixture
+- [x] Add truncated line coverage tests
 - [x] Open draft PR
 
 ## Notes

--- a/docs/checkins/WP-009.md
+++ b/docs/checkins/WP-009.md
@@ -14,3 +14,4 @@
 
 ## Notes
 - Observability not run (local codex CLI not available).
+- Validation: `npx pnpm@9.12.0 --filter @patchlings/adapters test`, `npx pnpm@9.12.0 --filter @patchlings/engine test`.

--- a/docs/checkins/WP-009.md
+++ b/docs/checkins/WP-009.md
@@ -1,0 +1,16 @@
+# WP-009 Check-ins — Replay Fixture + Truncated Line Coverage
+
+## Preflight
+- WP issue: #21
+- Branch: `wp/009-replay-fixture`
+- Commands to validate:
+  - `npx pnpm@9.12.0 --filter @patchlings/adapters test`
+  - `npx pnpm@9.12.0 --filter @patchlings/engine test`
+
+## Milestones
+- [ ] Add replay fixture
+- [ ] Add truncated line coverage tests
+- [ ] Open draft PR
+
+## Notes
+- Observability not run (local codex CLI not available).

--- a/docs/checkins/WP-009.md
+++ b/docs/checkins/WP-009.md
@@ -10,7 +10,7 @@
 ## Milestones
 - [ ] Add replay fixture
 - [ ] Add truncated line coverage tests
-- [ ] Open draft PR
+- [x] Open draft PR
 
 ## Notes
 - Observability not run (local codex CLI not available).

--- a/packages/adapters/test/file-tail.test.ts
+++ b/packages/adapters/test/file-tail.test.ts
@@ -1,0 +1,51 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { TelemetryEventV1 } from "@patchlings/protocol";
+import { fileTailAdapter } from "../src/index.js";
+
+describe("fileTailAdapter", () => {
+  it("handles truncated lines without crashing", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "patchlings-tail-"));
+    const filePath = path.join(dir, "recording.jsonl");
+
+    const goodLine = JSON.stringify({
+      v: 1,
+      run_id: "run-tail",
+      seq: 0,
+      ts: "2026-01-01T00:00:00.000Z",
+      kind: "turn",
+      name: "turn.started"
+    });
+    const truncatedLine = "{\"v\":1,\"run_id\":\"run-tail\",\"seq\":1";
+
+    await writeFile(filePath, `${goodLine}\n${truncatedLine}`);
+
+    const context = {
+      runId: "run-tail",
+      workspaceSalt: "workspace-salt",
+      runSalt: "run-salt",
+      getRunSalt: () => "run-salt"
+    };
+
+    const handle = await fileTailAdapter({
+      filePath,
+      context,
+      fromStart: true,
+      pollIntervalMs: 10,
+      endOnIdleMs: 50
+    });
+
+    const events: TelemetryEventV1[] = [];
+    for await (const event of handle.stream) {
+      events.push(event);
+    }
+    await handle.stop();
+
+    expect(events.some((event) => event.name === "turn.started")).toBe(true);
+    expect(events.some((event) => event.name === "log.unparsed_line")).toBe(true);
+  });
+});

--- a/packages/engine/test/fixtures/replay.jsonl
+++ b/packages/engine/test/fixtures/replay.jsonl
@@ -1,0 +1,6 @@
+{"v":1,"run_id":"run-fixture","seq":0,"ts":"2026-01-01T00:00:00.000Z","kind":"turn","name":"turn.started","attrs":{"label":"Turn 1"}}
+{"v":1,"run_id":"run-fixture","seq":1,"ts":"2026-01-01T00:00:01.000Z","kind":"tool","name":"tool.shell.start","attrs":{"tool_name":"shell"}}
+{"v":1,"run_id":"run-fixture","seq":2,"ts":"2026-01-01T00:00:02.000Z","kind":"file","name":"file.write","attrs":{"path":"src/demo.ts"}}
+{"v":1,"run_id":"run-fixture","seq":3,"ts":"2026-01-01T00:00:03.000Z","kind":"log","name":"log.progress","severity":"debug","attrs":{"message":"tick"}}
+{"v":1,"run_id":"run-fixture","seq":4,"ts":"2026-01-01T00:00:04.000Z","kind":"test","name":"test.pass","attrs":{"count":3}}
+{"v":1,"run_id":"run-fixture","seq":5,"ts":"2026-01-01T00:00:05.000Z","kind":"turn","name":"turn.completed"}

--- a/packages/engine/test/replay.fixture.test.ts
+++ b/packages/engine/test/replay.fixture.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import type { TelemetryEventV1 } from "@patchlings/protocol";
+
+import { PatchlingsEngine } from "../src/index.js";
+
+const FIXTURE_PATH = new URL("./fixtures/replay.jsonl", import.meta.url);
+
+function loadFixtureEvents(): TelemetryEventV1[] {
+  const text = readFileSync(FIXTURE_PATH, "utf8").trim();
+  if (!text) {
+    return [];
+  }
+  return text.split(/\r?\n/).map((line) => JSON.parse(line) as TelemetryEventV1);
+}
+
+describe("PatchlingsEngine replay fixture", () => {
+  it("replays fixture deterministically", async () => {
+    const events = loadFixtureEvents();
+    const runId = "run-fixture";
+
+    const createEngine = () =>
+      PatchlingsEngine.create({
+        storageMode: "memory",
+        eventsPerSecondThreshold: 3,
+        fixedSalts: {
+          workspaceSalt: "workspace-salt",
+          runSalts: {
+            [runId]: "run-salt"
+          }
+        }
+      });
+
+    const engineA = await createEngine();
+    const engineB = await createEngine();
+
+    await engineA.ingestBatch(events);
+    await engineB.ingestBatch(events);
+
+    expect(engineA.getChapters()).toEqual(engineB.getChapters());
+    expect(engineA.getChapters().length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- WP-009 scaffolding: add replay fixture plan and check-in.

## Checklist
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [ ] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes
Fixtures will be metadata-only.

## Monitoring Status
- Telemetry: not run (local codex CLI not available)
- Viewer: not run
- Risk: tests + fixtures only

Fixes #21
