### PR TITLE
WP-010: Release plan (semver + changelog + v0.1 exit)

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,46 @@
+# Release Plan
+
+This document defines how Patchlings versions are cut and what we consider a release-ready state.
+
+## SemVer Policy
+
+Patchlings follows semantic versioning (MAJOR.MINOR.PATCH).
+
+- **MAJOR**: breaking changes to public contracts (Telemetry schema, CLI flags, persisted storage layout, theme API).
+- **MINOR**: new features that are backwards compatible.
+- **PATCH**: bug fixes, docs improvements, and internal refactors with no behavior change.
+
+**Telemetry contract rule:** any breaking change to Telemetry v1 requires a protocol version bump and a migration note for downstream consumers.
+
+## Changelog Strategy
+
+We use a curated `CHANGELOG.md` at the repo root:
+
+- Each release gets a dated entry under the new version.
+- Sections include: Added, Changed, Fixed, Security (when relevant).
+- Only user-facing changes go into the changelog; purely internal refactors are omitted unless they affect behavior.
+
+## Release Steps (Manual)
+
+1. Ensure `main` is green (CI passing).
+2. Update `CHANGELOG.md` with the release notes.
+3. Bump version(s) where needed (root package.json and any published packages).
+4. Tag the release: `git tag vX.Y.Z`.
+5. Push tags: `git push --tags`.
+6. Create the GitHub release with notes copied from `CHANGELOG.md`.
+
+## v0.1 Exit Criteria
+
+A v0.1 release is ready when:
+
+- Protocol v1 is stable and documented.
+- Redaction + hashing defaults are verified and documented.
+- Engine persistence + chaptering are reliable.
+- Demo mode and Codex JSONL adapter are tested and usable.
+- Viewer renders Universe + Learn-lings + Story Time with safe defaults.
+- Deterministic replay fixture tests pass.
+- Docs (Quickstart, Architecture, Themes, Security) are current.
+
+## Notes
+
+This plan is intentionally lightweight to keep early releases fast and safe. We can automate parts of the process after v0.1.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,5 +20,4 @@ This roadmap is intentionally biased toward correctness, privacy, and determinis
 - Adapter plugin API and external agent examples
 - Recording browser and deterministic replay tooling
 - Theme pack publishing guide and theme registry
-- Release process (semver, changelog, versioned docs)
-
+- Release process (see docs/RELEASE.md)

--- a/docs/WP-010-release-plan.md
+++ b/docs/WP-010-release-plan.md
@@ -1,0 +1,26 @@
+# WP-010 — Release Plan (Semver + Changelog + v0.1 Exit)
+
+## Goal
+Document the Patchlings release plan: semver policy, changelog strategy, and v0.1 exit criteria.
+
+## Scope (In)
+- Add/extend docs that define semver policy and changelog strategy.
+- Document release steps and v0.1 exit criteria.
+
+## Scope (Out)
+- Release automation or CI changes.
+
+## Constraints
+- Privacy-first documentation.
+- No runtime behavior changes.
+
+## Plan
+1. Add a release plan doc (or update ROADMAP) with semver + changelog policy.
+2. Define v0.1 exit criteria.
+3. Cross-link from ROADMAP if needed.
+
+## Acceptance Criteria
+- Semver policy documented (including telemetry contract implications).
+- Changelog strategy documented.
+- Release steps documented (version bump, tag, release notes).
+- v0.1 exit criteria explicit.

--- a/docs/checkins/WP-010.md
+++ b/docs/checkins/WP-010.md
@@ -8,7 +8,7 @@
 
 ## Milestones
 - [x] Draft release plan doc
-- [ ] Open draft PR
+- [x] Open draft PR
 
 ## Notes
 - Observability not run (doc-only change; codex CLI not available).

--- a/docs/checkins/WP-010.md
+++ b/docs/checkins/WP-010.md
@@ -1,0 +1,14 @@
+# WP-010 Check-ins — Release Plan
+
+## Preflight
+- WP issue: #26
+- Branch: `wp/010-release-plan`
+- Commands to validate:
+  - (doc-only change)
+
+## Milestones
+- [x] Draft release plan doc
+- [ ] Open draft PR
+
+## Notes
+- Observability not run (doc-only change; codex CLI not available).


### PR DESCRIPTION
## Summary
- Add release plan doc (semver, changelog, v0.1 exit criteria).
- Link ROADMAP to the release plan doc.

## Checklist
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [x] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes
Doc-only change.

## Monitoring Status
- Telemetry: not run (doc-only change; codex CLI not available)
- Viewer: not run
- Risk: docs only

Fixes #26
