### PR TITLE
WP-011: Colony sim stability + demo loop

### DIFF
--- a/apps/runner/src/cli.ts
+++ b/apps/runner/src/cli.ts
@@ -546,7 +546,7 @@ async function selectAdapter(engine: PatchlingsEngine, options: RunnerOptions, r
   const context = await buildAdapterContext(engine, runId);
 
   if (options.command === "demo" || options.command === "dev") {
-    return demoAdapter({ context });
+    return demoAdapter({ context, loop: true });
   }
 
   if (options.command === "stdin") {

--- a/docs/WP-011-colony-sim-stability-demo-loop.md
+++ b/docs/WP-011-colony-sim-stability-demo-loop.md
@@ -1,0 +1,27 @@
+# WP-011 — Colony Sim Stability + Demo Loop
+
+## Goal
+Keep the Pixi colony feeling alive: fix sprite refresh crash, add ambient wandering, and loop demo telemetry so the viewer never goes idle.
+
+## Scope (In)
+- Guard AnimatedSprite refresh to avoid destroying shared textures.
+- Add idle wander timing so agents keep moving when no jobs are queued.
+- Add a demo adapter loop option and enable it for `patchlings demo`/`dev`.
+
+## Scope (Out)
+- New art assets or visual design changes.
+- Protocol/engine changes.
+
+## Constraints
+- Privacy-safe logs only.
+- Minimal behavior changes outside the viewer/demo adapter.
+
+## Plan
+1. Harden sprite refresh teardown to avoid Pixi destroy crashes.
+2. Add idle wander cadence so agents keep moving.
+3. Add demo loop option + wire runner to enable it for demo/dev.
+
+## Acceptance Criteria
+- Demo runs continuously without stopping.
+- Agents keep ambient motion when idle.
+- No console crash during sprite refresh.

--- a/docs/checkins/WP-011.md
+++ b/docs/checkins/WP-011.md
@@ -16,4 +16,7 @@
 ## Notes
 - Observability: `codex` CLI not found in PATH; unable to run `codex exec --json`.
 - Untracked file in worktree: `patchlings-snapshots.js` (left untouched).
-- Validation: not run yet (demo/viewer/typecheck pending).
+- Validation:
+  - `npx pnpm@9.12.0 --filter @patchlings/viewer build`
+  - `npx pnpm@9.12.0 --filter @patchlings/adapters build`
+  - `npx pnpm@9.12.0 --filter @patchlings/runner build`

--- a/docs/checkins/WP-011.md
+++ b/docs/checkins/WP-011.md
@@ -1,0 +1,18 @@
+# WP-011 Check-ins — Colony Sim Stability + Demo Loop
+
+## Preflight
+- WP issue: #28
+- Branch: `wp/011-colony-sim-stability-demo-loop`
+- Commands to validate:
+  - pnpm --filter @patchlings/viewer dev
+  - pnpm demo
+
+## Milestones
+- [ ] Fix sprite refresh teardown (avoid texture destroy crash)
+- [ ] Add idle wander cadence
+- [ ] Loop demo adapter + runner wiring
+- [ ] Open draft PR
+
+## Notes
+- Observability: `codex` CLI not found in PATH; unable to run `codex exec --json`.
+- Untracked file in worktree: `patchlings-snapshots.js` (left untouched).

--- a/docs/checkins/WP-011.md
+++ b/docs/checkins/WP-011.md
@@ -8,11 +8,12 @@
   - pnpm demo
 
 ## Milestones
-- [ ] Fix sprite refresh teardown (avoid texture destroy crash)
-- [ ] Add idle wander cadence
-- [ ] Loop demo adapter + runner wiring
-- [ ] Open draft PR
+- [x] Fix sprite refresh teardown (avoid texture destroy crash)
+- [x] Add idle wander cadence
+- [x] Loop demo adapter + runner wiring
+- [x] Open draft PR
 
 ## Notes
 - Observability: `codex` CLI not found in PATH; unable to run `codex exec --json`.
 - Untracked file in worktree: `patchlings-snapshots.js` (left untouched).
+- Validation: not run yet (demo/viewer/typecheck pending).


### PR DESCRIPTION
## Summary

WP-011: stabilize the Pixi colony sim by avoiding shared-texture destroy crashes, keep idle agents wandering, and loop the demo adapter so the viewer stays active.

## Monitoring Status
- Codex JSONL: unavailable (codex CLI not found in PATH).
- Patchlings demo: running (looping) on http://localhost:4318.
- Viewer: running (Sprites: Loaded).

## Validation Notes
- `npx pnpm@9.12.0 --filter @patchlings/viewer build`
- `npx pnpm@9.12.0 --filter @patchlings/adapters build`
- `npx pnpm@9.12.0 --filter @patchlings/runner build`

## Checklist

- [ ] I ran `pnpm test`
- [ ] I ran `pnpm typecheck`
- [ ] I ran `pnpm build`
- [ ] I updated docs if behavior changed
- [x] I considered privacy and redaction impacts

## Privacy Notes

No telemetry content surfaced; changes are limited to animation/idle behavior and demo event cadence.

Fixes #28
